### PR TITLE
Adding fix for unhandled exception code smell

### DIFF
--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -17,6 +17,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import IntegrationError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -287,11 +288,11 @@ class PhilipsTVLightEntity(
         }
 
         if not await self._tv.setAmbilightCached(data):
-            raise SystemExit("Failed to set ambilight color")
+            raise IntegrationError("Failed to set ambilight color")
 
         if effect.style != self._tv.ambilight_mode:
             if not await self._tv.setAmbilightMode(effect.style):
-                raise SystemExit("Failed to set ambilight mode")
+                raise IntegrationError("Failed to set ambilight mode")
 
     async def _set_ambilight_expert_config(
         self, effect: AmbilightEffect, hs_color: tuple[float, float], brightness: int
@@ -325,7 +326,7 @@ class PhilipsTVLightEntity(
             config["tuning"] = 0
 
         if not await self._tv.setAmbilightCurrentConfiguration(config):
-            raise SystemExit("Failed to set ambilight mode")
+            raise IntegrationError("Failed to set ambilight mode")
 
     async def _set_ambilight_config(self, effect: AmbilightEffect):
         """Set ambilight via current configuration."""
@@ -336,7 +337,7 @@ class PhilipsTVLightEntity(
         }
 
         if await self._tv.setAmbilightCurrentConfiguration(config) is False:
-            raise SystemExit("Failed to set ambilight mode")
+            raise IntegrationError("Failed to set ambilight mode")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the bulb on."""
@@ -345,7 +346,7 @@ class PhilipsTVLightEntity(
         attr_effect = kwargs.get(ATTR_EFFECT, self.effect)
 
         if not self._tv.on:
-            raise SystemExit("TV is not available")
+            raise IntegrationError("TV is not available")
 
         effect = AmbilightEffect.from_str(attr_effect)
 
@@ -383,10 +384,10 @@ class PhilipsTVLightEntity(
         """Turn of ambilight."""
 
         if not self._tv.on:
-            raise SystemExit("TV is not available")
+            raise IntegrationError("TV is not available")
 
         if await self._tv.setAmbilightMode("internal") is False:
-            raise SystemExit("Failed to set ambilight mode")
+            raise IntegrationError("Failed to set ambilight mode")
 
         await self._set_ambilight_config(AmbilightEffect(EFFECT_MODE, "OFF", ""))
 

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -287,11 +287,11 @@ class PhilipsTVLightEntity(
         }
 
         if not await self._tv.setAmbilightCached(data):
-            raise Exception("Failed to set ambilight color")
+            raise SystemExit("Failed to set ambilight color")
 
         if effect.style != self._tv.ambilight_mode:
             if not await self._tv.setAmbilightMode(effect.style):
-                raise Exception("Failed to set ambilight mode")
+                raise SystemExit("Failed to set ambilight mode")
 
     async def _set_ambilight_expert_config(
         self, effect: AmbilightEffect, hs_color: tuple[float, float], brightness: int
@@ -325,7 +325,7 @@ class PhilipsTVLightEntity(
             config["tuning"] = 0
 
         if not await self._tv.setAmbilightCurrentConfiguration(config):
-            raise Exception("Failed to set ambilight mode")
+            raise SystemExit("Failed to set ambilight mode")
 
     async def _set_ambilight_config(self, effect: AmbilightEffect):
         """Set ambilight via current configuration."""
@@ -336,7 +336,7 @@ class PhilipsTVLightEntity(
         }
 
         if await self._tv.setAmbilightCurrentConfiguration(config) is False:
-            raise Exception("Failed to set ambilight mode")
+            raise SystemExit("Failed to set ambilight mode")
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the bulb on."""
@@ -345,7 +345,7 @@ class PhilipsTVLightEntity(
         attr_effect = kwargs.get(ATTR_EFFECT, self.effect)
 
         if not self._tv.on:
-            raise Exception("TV is not available")
+            raise SystemExit("TV is not available")
 
         effect = AmbilightEffect.from_str(attr_effect)
 
@@ -383,10 +383,10 @@ class PhilipsTVLightEntity(
         """Turn of ambilight."""
 
         if not self._tv.on:
-            raise Exception("TV is not available")
+            raise SystemExit("TV is not available")
 
         if await self._tv.setAmbilightMode("internal") is False:
-            raise Exception("Failed to set ambilight mode")
+            raise SystemExit("Failed to set ambilight mode")
 
         await self._set_ambilight_config(AmbilightEffect(EFFECT_MODE, "OFF", ""))
 

--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -128,11 +128,11 @@ class TwitchSensor(SensorEntity):
             elif "status" in subs and subs["status"] == 404:
                 self._attr_extra_state_attributes[ATTR_SUBSCRIPTION] = False
             elif "error" in subs:
-                raise Exception(
+                raise SystemExit(
                     f"Error response on check_user_subscription: {subs['error']}"
                 )
             else:
-                raise Exception("Unknown error response on check_user_subscription")
+                raise SystemExit("Unknown error response on check_user_subscription")
 
             follows = self._client.get_users_follows(
                 from_id=user, to_id=self.unique_id

--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -16,6 +16,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_TOKEN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import IntegrationError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -128,11 +129,13 @@ class TwitchSensor(SensorEntity):
             elif "status" in subs and subs["status"] == 404:
                 self._attr_extra_state_attributes[ATTR_SUBSCRIPTION] = False
             elif "error" in subs:
-                raise SystemExit(
+                raise IntegrationError(
                     f"Error response on check_user_subscription: {subs['error']}"
                 )
             else:
-                raise SystemExit("Unknown error response on check_user_subscription")
+                raise IntegrationError(
+                    "Unknown error response on check_user_subscription"
+                )
 
             follows = self._client.get_users_follows(
                 from_id=user, to_id=self.unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
Motivation:
what is the issue/code smell?
rename this variable;it shows a shadow built-in

why is this issue/code smell relevant?
It is a relevant code smell related to error handling issue, when an exception instance is raised unnecessarily makes the code error prone to catch these kind of exceptions. In some cases it is better to remove an exception that is not being raised at all in the code. this make the code more complex and difficult to maintain.

How is the issue resolved?
The issue can be resolved by renaming the exception to more suitable exceptions such as SystemExit. In other cases an unraised exception should be removed from the code to make it more simpler. I chose to replace the exception with SystemExit as the code that raise the exception doesn't gives any kind of output when executed. 
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
