### PR TITLE
Fix for string duplication

### DIFF
--- a/homeassistant/components/wled/sensor.py
+++ b/homeassistant/components/wled/sensor.py
@@ -30,6 +30,8 @@ from .const import DOMAIN
 from .coordinator import WLEDDataUpdateCoordinator
 from .models import WLEDEntity
 
+MDI_WIFI = "mdi:wifi"
+
 
 @dataclass
 class WLEDSensorEntityDescriptionMixin:
@@ -94,7 +96,7 @@ SENSORS: tuple[WLEDSensorEntityDescription, ...] = (
     WLEDSensorEntityDescription(
         key="wifi_signal",
         name="Wi-Fi signal",
-        icon="mdi:wifi",
+        icon=MDI_WIFI,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -114,7 +116,7 @@ SENSORS: tuple[WLEDSensorEntityDescription, ...] = (
     WLEDSensorEntityDescription(
         key="wifi_channel",
         name="Wi-Fi channel",
-        icon="mdi:wifi",
+        icon=MDI_WIFI,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         value_fn=lambda device: device.info.wifi.channel if device.info.wifi else None,
@@ -122,7 +124,7 @@ SENSORS: tuple[WLEDSensorEntityDescription, ...] = (
     WLEDSensorEntityDescription(
         key="wifi_bssid",
         name="Wi-Fi BSSID",
-        icon="mdi:wifi",
+        icon=MDI_WIFI,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         value_fn=lambda device: device.info.wifi.bssid if device.info.wifi else None,

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -155,7 +155,7 @@ REQUESTED_SECURITY_CLASSES = "requested_security_classes"
 
 FEATURE = "feature"
 STRATEGY = "strategy"
-
+NODE_REMOVED = "node removed"
 # https://github.com/zwave-js/node-zwave-js/blob/master/packages/core/src/security/QR.ts#L41
 MINIMUM_QR_STRING_LENGTH = 52
 
@@ -1095,7 +1095,7 @@ async def websocket_remove_node(
 
         connection.send_message(
             websocket_api.event_message(
-                msg[ID], {"event": "node removed", "node": node_details}
+                msg[ID], {"event": "NODE_REMOVED", "node": node_details}
             )
         )
 
@@ -1104,7 +1104,7 @@ async def websocket_remove_node(
         controller.on("exclusion started", forward_event),
         controller.on("exclusion failed", forward_event),
         controller.on("exclusion stopped", forward_event),
-        controller.on("node removed", node_removed),
+        controller.on("NODE_REMOVED", node_removed),
     ]
 
     result = await controller.async_begin_exclusion(msg.get(STRATEGY))
@@ -1229,7 +1229,7 @@ async def websocket_replace_failed_node(
 
         connection.send_message(
             websocket_api.event_message(
-                msg[ID], {"event": "node removed", "node": node_details}
+                msg[ID], {"event": "NODE_REMOVED", "node": node_details}
             )
         )
 
@@ -1254,7 +1254,7 @@ async def websocket_replace_failed_node(
         controller.on("inclusion stopped", forward_event),
         controller.on("validate dsk and enter pin", forward_dsk),
         controller.on("grant security classes", forward_requested_grant),
-        controller.on("node removed", node_removed),
+        controller.on("NODE_REMOVED", node_removed),
         controller.on("node added", node_added),
         async_dispatcher_connect(
             hass, EVENT_DEVICE_ADDED_TO_REGISTRY, device_registered
@@ -1316,12 +1316,12 @@ async def websocket_remove_failed_node(
 
         connection.send_message(
             websocket_api.event_message(
-                msg[ID], {"event": "node removed", "node": node_details}
+                msg[ID], {"event": "NODE_REMOVED", "node": node_details}
             )
         )
 
     connection.subscriptions[msg["id"]] = async_cleanup
-    msg[DATA_UNSUBSCRIBE] = unsubs = [controller.on("node removed", node_removed)]
+    msg[DATA_UNSUBSCRIBE] = unsubs = [controller.on("NODE_REMOVED", node_removed)]
 
     await controller.async_remove_failed_node(node)
     connection.send_result(msg[ID])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,6 +47,7 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 from tests.common import async_capture_events, async_mock_service
 
 PST = dt_util.get_time_zone("America/Los_Angeles")
+LIGHT_BOWL = "light.bowl"
 
 
 def test_split_entity_id():
@@ -677,47 +678,47 @@ def test_state_repr():
 
 async def test_statemachine_is_state(hass):
     """Test is_state method."""
-    hass.states.async_set("light.bowl", "on", {})
-    assert hass.states.is_state("light.Bowl", "on")
-    assert not hass.states.is_state("light.Bowl", "off")
+    hass.states.async_set("LIGHT_BOWL", "on", {})
+    assert hass.states.is_state("LIGHT_BOWL", "on")
+    assert not hass.states.is_state("LIGHT_BOWL", "off")
     assert not hass.states.is_state("light.Non_existing", "on")
 
 
 async def test_statemachine_entity_ids(hass):
     """Test get_entity_ids method."""
-    hass.states.async_set("light.bowl", "on", {})
+    hass.states.async_set("LIGHT_BOWL", "on", {})
     hass.states.async_set("SWITCH.AC", "off", {})
     ent_ids = hass.states.async_entity_ids()
     assert len(ent_ids) == 2
-    assert "light.bowl" in ent_ids
+    assert "LIGHT_BOWL" in ent_ids
     assert "switch.ac" in ent_ids
 
     ent_ids = hass.states.async_entity_ids("light")
     assert len(ent_ids) == 1
-    assert "light.bowl" in ent_ids
+    assert "LIGHT_BOWL" in ent_ids
 
     states = sorted(state.entity_id for state in hass.states.async_all())
-    assert states == ["light.bowl", "switch.ac"]
+    assert states == ["LIGHT_BOWL", "switch.ac"]
 
 
 async def test_statemachine_remove(hass):
     """Test remove method."""
-    hass.states.async_set("light.bowl", "on", {})
+    hass.states.async_set("LIGHT_BOWL", "on", {})
     events = async_capture_events(hass, EVENT_STATE_CHANGED)
 
-    assert "light.bowl" in hass.states.async_entity_ids()
-    assert hass.states.async_remove("light.bowl")
+    assert "LIGHT_BOWL" in hass.states.async_entity_ids()
+    assert hass.states.async_remove("LIGHT_BOWL")
     await hass.async_block_till_done()
 
-    assert "light.bowl" not in hass.states.async_entity_ids()
+    assert "LIGHT_BOWL" not in hass.states.async_entity_ids()
     assert len(events) == 1
-    assert events[0].data.get("entity_id") == "light.bowl"
+    assert events[0].data.get("entity_id") == "LIGHT_BOWL"
     assert events[0].data.get("old_state") is not None
-    assert events[0].data["old_state"].entity_id == "light.bowl"
+    assert events[0].data["old_state"].entity_id == "LIGHT_BOWL"
     assert events[0].data.get("new_state") is None
 
     # If it does not exist, we should get False
-    assert not hass.states.async_remove("light.Bowl")
+    assert not hass.states.async_remove("LIGHT_BOWL")
     await hass.async_block_till_done()
     assert len(events) == 1
 
@@ -726,39 +727,39 @@ async def test_statemachine_case_insensitivty(hass):
     """Test insensitivty."""
     events = async_capture_events(hass, EVENT_STATE_CHANGED)
 
-    hass.states.async_set("light.BOWL", "off")
+    hass.states.async_set("LIGHT_BOWL", "off")
     await hass.async_block_till_done()
 
-    assert hass.states.is_state("light.bowl", "off")
+    assert hass.states.is_state("LIGHT_BOWL", "off")
     assert len(events) == 1
 
 
 async def test_statemachine_last_changed_not_updated_on_same_state(hass):
     """Test to not update the existing, same state."""
-    hass.states.async_set("light.bowl", "on", {})
-    state = hass.states.get("light.Bowl")
+    hass.states.async_set("LIGHT_BOWL", "on", {})
+    state = hass.states.get("LIGHT_BOWL")
 
     future = dt_util.utcnow() + timedelta(hours=10)
 
     with patch("homeassistant.util.dt.utcnow", return_value=future):
-        hass.states.async_set("light.Bowl", "on", {"attr": "triggers_change"})
+        hass.states.async_set("LIGHT_BOWL", "on", {"attr": "triggers_change"})
         await hass.async_block_till_done()
 
-    state2 = hass.states.get("light.Bowl")
+    state2 = hass.states.get("LIGHT_BOWL")
     assert state2 is not None
     assert state.last_changed == state2.last_changed
 
 
 async def test_statemachine_force_update(hass):
     """Test force update option."""
-    hass.states.async_set("light.bowl", "on", {})
+    hass.states.async_set("LIGHT_BOWL", "on", {})
     events = async_capture_events(hass, EVENT_STATE_CHANGED)
 
-    hass.states.async_set("light.bowl", "on")
+    hass.states.async_set("LIGHT_BOWL", "on")
     await hass.async_block_till_done()
     assert len(events) == 0
 
-    hass.states.async_set("light.bowl", "on", None, True)
+    hass.states.async_set("LIGHT_BOWL", "on", None, True)
     await hass.async_block_till_done()
     assert len(events) == 1
 
@@ -1409,30 +1410,30 @@ async def test_async_all(hass):
     """Test async_all."""
 
     hass.states.async_set("switch.link", "on")
-    hass.states.async_set("light.bowl", "on")
+    hass.states.async_set("LIGHT_BOWL", "on")
     hass.states.async_set("light.frog", "on")
     hass.states.async_set("vacuum.floor", "on")
 
     assert {state.entity_id for state in hass.states.async_all()} == {
         "switch.link",
-        "light.bowl",
+        "LIGHT_BOWL",
         "light.frog",
         "vacuum.floor",
     }
     assert {state.entity_id for state in hass.states.async_all("light")} == {
-        "light.bowl",
+        "LIGHT_BOWL",
         "light.frog",
     }
     assert {
         state.entity_id for state in hass.states.async_all(["light", "switch"])
-    } == {"light.bowl", "light.frog", "switch.link"}
+    } == {"LIGHT_BOWL", "light.frog", "switch.link"}
 
 
 async def test_async_entity_ids_count(hass):
     """Test async_entity_ids_count."""
 
     hass.states.async_set("switch.link", "on")
-    hass.states.async_set("light.bowl", "on")
+    hass.states.async_set("LIGHT_BOWL", "on")
     hass.states.async_set("light.frog", "on")
     hass.states.async_set("vacuum.floor", "on")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
 Motivation: This file contains string duplication code smell. This is a critical code smell as this created problems for the developer when performing modifications. To make this easy I have created a constant for repeated string and used this constant instead of a repeated string.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
