### PR TITLE
deleting the config entry the unused variable

### DIFF
--- a/homeassistant/components/acmeda/helpers.py
+++ b/homeassistant/components/acmeda/helpers.py
@@ -34,7 +34,7 @@ def async_add_acmeda_entities(
     async_add_entities(new_items)
 
 
-async def update_devices(hass: HomeAssistant, config_entry: ConfigEntry, api):
+async def update_devices(hass: HomeAssistant, api):
     """Tell hass that device info has been updated."""
     dev_registry = dr.async_get(hass)
 


### PR DESCRIPTION
## Breaking change

## Proposed change
The config_entry parameter is unused in the function, no need to add more parameter that unnecessary for the function.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

Tarek Alhoumsi group 10

Rule 2: the reason why this issue/code smell is relevant, because it makes the reader or the other programmers who read the code confused about the parameter, adding parameter to a function then is never used make some confusion.

Rule 3: just deleting the unused parameter will not affect the function because it worked fine even when they parameter is declared in the function parameters but never used so deleting it would not cause any issues. 
