### PR TITLE
reduced cognitive complexity of the function async_update_state() in …

### DIFF
--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -218,36 +218,24 @@ class Fan(HomeAccessory):
     @callback
     def async_update_state(self, new_state):
         """Update fan after state change."""
-        # Handle State
         state = new_state.state
         attributes = new_state.attributes
+
+        # Handle State
         if state in (STATE_ON, STATE_OFF):
             self._state = 1 if state == STATE_ON else 0
             self.char_active.set_value(self._state)
 
         # Handle Direction
         if self.char_direction is not None:
-            direction = new_state.attributes.get(ATTR_DIRECTION)
+            direction = attributes.get(ATTR_DIRECTION)
             if direction in (DIRECTION_FORWARD, DIRECTION_REVERSE):
                 hk_direction = 1 if direction == DIRECTION_REVERSE else 0
                 self.char_direction.set_value(hk_direction)
 
         # Handle Speed
         if self.char_speed is not None and state != STATE_OFF:
-            # We do not change the homekit speed when turning off
-            # as it will clear the restore state
             percentage = attributes.get(ATTR_PERCENTAGE)
-            # If the homeassistant component reports its speed as the first entry
-            # in its speed list but is not off, the hk_speed_value is 0. But 0
-            # is a special value in homekit. When you turn on a homekit accessory
-            # it will try to restore the last rotation speed state which will be
-            # the last value saved by char_speed.set_value. But if it is set to
-            # 0, HomeKit will update the rotation speed to 100 as it thinks 0 is
-            # off.
-            #
-            # Therefore, if the hk_speed_value is 0 and the device is still on,
-            # the rotation speed is mapped to 1 otherwise the update is ignored
-            # in order to avoid this incorrect behavior.
             if percentage == 0 and state == STATE_ON:
                 percentage = max(1, self.char_speed.properties[PROP_MIN_STEP])
             if percentage is not None:
@@ -260,9 +248,9 @@ class Fan(HomeAccessory):
                 hk_oscillating = 1 if oscillating else 0
                 self.char_swing.set_value(hk_oscillating)
 
+        # Handle Preset Mode
         current_preset_mode = attributes.get(ATTR_PRESET_MODE)
         if self.char_target_fan_state is not None:
-            # Handle single preset mode
             self.char_target_fan_state.set_value(int(current_preset_mode is not None))
             return
 
@@ -270,3 +258,4 @@ class Fan(HomeAccessory):
         for preset_mode, char in self.preset_mode_chars.items():
             hk_value = 1 if preset_mode == current_preset_mode else 0
             char.set_value(hk_value)
+


### PR DESCRIPTION
…homekit/type_fans.py

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr




Code smell: Reducing cognitive complexity of a function

Why is this code smell/issue relevant?
A function with higher cognitive complexity is difficult to understand. If a developer wants to make any changes to a function with higher complexity, they would take a lot of time to understand the function. The function will be less readable, and it will take more effort to maintain, debug, and test. Hence, the function's cognitive complexity should be reduced to make it more understandable and easier to maintain and debug, saving time and effort.

How the code smell/issue is resolved?
The cognitive complexity of a function can be resolved by breaking down the function into smaller components, simplifying logic (reducing the usage of if-else statements and loops), using meaningful variable names.
In this PR, I have removed redundant conditions and restructured the code 