### PR TITLE
Replaced the duplicated string with a constant in the Tautulli integr…

### DIFF
--- a/homeassistant/components/tautulli/sensor.py
+++ b/homeassistant/components/tautulli/sensor.py
@@ -29,6 +29,8 @@ from . import TautulliEntity
 from .const import ATTR_TOP_USER, DOMAIN
 from .coordinator import TautulliDataUpdateCoordinator
 
+plex = "mdi:plex"
+
 
 def get_top_stats(
     home_stats: PyTautulliApiHomeStats, activity: PyTautulliApiActivity, key: str
@@ -59,14 +61,14 @@ class TautulliSensorEntityDescription(
 
 SENSOR_TYPES: tuple[TautulliSensorEntityDescription, ...] = (
     TautulliSensorEntityDescription(
-        icon="mdi:plex",
+        icon=plex,
         key="watching_count",
         translation_key="watching_count",
         native_unit_of_measurement="Watching",
         value_fn=lambda home_stats, activity, _: cast(int, activity.stream_count),
     ),
     TautulliSensorEntityDescription(
-        icon="mdi:plex",
+        icon=plex,
         key="stream_count_direct_play",
         translation_key="stream_count_direct_play",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -77,7 +79,7 @@ SENSOR_TYPES: tuple[TautulliSensorEntityDescription, ...] = (
         ),
     ),
     TautulliSensorEntityDescription(
-        icon="mdi:plex",
+        icon=plex,
         key="stream_count_direct_stream",
         translation_key="stream_count_direct_stream",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -88,7 +90,7 @@ SENSOR_TYPES: tuple[TautulliSensorEntityDescription, ...] = (
         ),
     ),
     TautulliSensorEntityDescription(
-        icon="mdi:plex",
+        icon=plex,
         key="stream_count_transcode",
         translation_key="stream_count_transcode",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -167,7 +169,7 @@ class TautulliSessionSensorEntityDescription(
 
 SESSION_SENSOR_TYPES: tuple[TautulliSessionSensorEntityDescription, ...] = (
     TautulliSessionSensorEntityDescription(
-        icon="mdi:plex",
+        icon=plex,
         key="state",
         translation_key="state",
         value_fn=lambda session: cast(str, session.state),
@@ -194,7 +196,7 @@ SESSION_SENSOR_TYPES: tuple[TautulliSessionSensorEntityDescription, ...] = (
         value_fn=lambda session: cast(str, session.stream_video_resolution),
     ),
     TautulliSessionSensorEntityDescription(
-        icon="mdi:plex",
+        icon=plex,
         key="transcode_decision",
         translation_key="transcode_decision",
         entity_category=EntityCategory.DIAGNOSTIC,


### PR DESCRIPTION
…ation

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaced the duplicated string in the Tautulli integration in order to improve maintainability. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


Kishor Peneff Group 10

2: The duplicate strings increase the time it would take to change the icon represented by the strings. The reason is that every occurrence of the string would need to be changed. 

3: The strings have been replaced by a constant with the value of the string. This makes it much quicker to change the icon, as one only needs to change the value of the constant and the icon change will be reflected throughout the file. 


