### PR TITLE
getting rid off duplicate code

### DIFF
--- a/homeassistant/components/thread/config_flow.py
+++ b/homeassistant/components/thread/config_flow.py
@@ -15,19 +15,22 @@ class ThreadConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    async def _async_shared_setup(self) -> FlowResult:
+        """Shared setup logic."""
+        await self._async_handle_discovery_without_unique_id()
+        return self.async_create_entry(title="Thread", data={})
+
     async def async_step_import(
         self, import_data: dict[str, str] | None = None
     ) -> FlowResult:
         """Set up by import from async_setup."""
-        await self._async_handle_discovery_without_unique_id()
-        return self.async_create_entry(title="Thread", data={})
+        return await self._async_shared_setup()
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
     ) -> FlowResult:
-        """Set up by import from async_setup."""
-        await self._async_handle_discovery_without_unique_id()
-        return self.async_create_entry(title="Thread", data={})
+        """Set up by user."""
+        return await self._async_shared_setup()
 
     async def async_step_zeroconf(
         self, discovery_info: zeroconf.ZeroconfServiceInfo


### PR DESCRIPTION
## Breaking change

## Proposed change
there is two functions that identical but the difference is just the name of the variable that has dictionary but the rest of the function is all similar so i tried to change the second function only but it did not work i tried so much different ways but it keep complaining so i made a help function that i could call in the two similar functions. 

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

Tarek Alhoumsi group 10

Rule 2: the reason why this issue/ code smell is relevant is because the two function is so much similar it is jut one difference between the two function which is the name of the dictionary and this creates duplication and it is like just a rewrite for the first function.

Rule 3: First i tried to call the first function in the second function but it did it not work, tried also to make if statment not none but also did not work then i tried to just create variable and give them same input or data that will be returned in the return statement and then use them in the return statement but this is not that much of change for the code so i thought that it is better to refactor or change both of the function so i created helper function that contain all the similar call parts from both of the functions and then call this helper function in the two similar function when i want to use these parts. The tests worked fine no error messages and it is pretty similar ass the way that they were before but it is just taking the call function from helper function instead of writing them in the two similar functions.