### PR TITLE
annotate iterate_packets as asyncgenerator

### DIFF
--- a/homeassistant/components/esphome/voice_assistant.py
+++ b/homeassistant/components/esphome/voice_assistant.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterable, Callable
+from collections.abc import AsyncGenerator, Callable
 import logging
 import socket
 from typing import cast
@@ -140,7 +140,7 @@ class VoiceAssistantUDPServer(asyncio.DatagramProtocol):
         if self.transport is not None:
             self.transport.close()
 
-    async def _iterate_packets(self) -> AsyncIterable[bytes]:
+    async def _iterate_packets(self) -> AsyncGenerator[bytes, None]:
         """Iterate over incoming packets."""
         if not self.started or self.stopped:
             raise RuntimeError("Not running")


### PR DESCRIPTION
## Breaking change

## Proposed change
Changed the Iterate_packets function to use the AsyncGenereator type hint.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

Tarek Alhoumsi group 10

Rule 2: the reason why this issue/code smell is relevant because type hint issue lead to potential errors so the function type should be correct not take type hint and then return another thing.

Rule 3: i used the asyncgeneretaor type hint so the function now works correctly, i got some errors while tired to refactor and i made mistake that i pushed wrong refactor and it causes problems with git and my branch so it took time to fixe the branch and the changes but when i run the tests it all works not giving errors like the first time tried to refactor. it took my a while to understand the import issue that the test were complaining about.
