### PR TITLE
annotate wake_word_audio_stream  as asyncgenerator

### DIFF
--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -573,7 +573,7 @@ class PipelineRun:
         wake_word_vad: VoiceActivityTimeout | None,
         sample_rate: int = 16000,
         sample_width: int = 2,
-    ) -> AsyncIterable[tuple[bytes, int]]:
+    ) -> AsyncGenerator[tuple[bytes, int], None]:
         """Yield audio chunks with timestamps (milliseconds since start of stream).
 
         Adds audio to a ring buffer that will be forwarded to speech-to-text after


### PR DESCRIPTION
## Breaking change

## Proposed change
replaced the AsyncIterable with Asyngenereator to imrpove maintainbility.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

Tarek Alhoumsi group 10

Rule 2: the reason why this issue/code smell is relevant because the type hint issue lead to potential errors in the code maintenance 

Rule 3: the AsyncGenerator implemeted instead of the AsyncIterable  to avoid the issue of the type hint, the Asyncgenerator were imported in the library but the AsyncIterable were used in the function instead but now the code is more maintainable and readable due the right type of hint.