### PR TITLE
Giving the return an value type

### DIFF
--- a/homeassistant/components/assist_pipeline/vad.py
+++ b/homeassistant/components/assist_pipeline/vad.py
@@ -280,7 +280,7 @@ def chunk_samples(
     if (len(leftover_chunk_buffer) + len(samples)) < bytes_per_chunk:
         # Extend leftover chunk, but not enough samples to complete it
         leftover_chunk_buffer.append(samples)
-        return
+        return Iterable[bytes]
 
     next_chunk_idx = 0
 


### PR DESCRIPTION
## Breaking change

## Proposed change
Giving the return statement a value type so it returns the correct value type


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

Tarek Alhoumsi group 10

Rule 2: the reason why this issue/code smell is relevant because it do not return the right value, the function need to return the expected value and this improves maintainability and also makes it easier to understand.

Rule 3: i used the iterable bytes in the return so the function return the expected value of iterable bytes. the test worked even when i changed the type hin to none and return iterable bytes i dont know if the testes really good that the developer made for this function. 