### PR TITLE
change of type hint in the get_debug_targets

### DIFF
--- a/homeassistant/components/conversation/__init__.py
+++ b/homeassistant/components/conversation/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 import logging
 import re
@@ -350,7 +350,7 @@ async def websocket_hass_agent_debug(
 def _get_debug_targets(
     hass: HomeAssistant,
     result: RecognizeResult,
-) -> Iterable[tuple[core.State, bool]]:
+) -> Generator[tuple[core.State, bool], None, None]:
     """Yield state/is_matched pairs for a hassil recognition."""
     entities = result.entities
 


### PR DESCRIPTION
## Breaking change

## Proposed change
changing the type hint to generator to improve maintainability. 


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

Tarek Alhoumsi group 10

Rule 2: the reason why this issue/code smell is relevant because type hint lead to potential errors in the code maintenance and the type should be the correct type

Rule 3: Generator were imported in the library then the type hint in the function were changing to it to improve code maintainability, got some issue with ruff when i used the git commit but solve it some how but the tests runs and its getting the correct type hint.