### PR TITLE
Group 9: String duplicate refractoring (Second try)

### DIFF
--- a/homeassistant/components/airthings_ble/const.py
+++ b/homeassistant/components/airthings_ble/const.py
@@ -7,3 +7,5 @@ VOLUME_BECQUEREL = "Bq/m³"
 VOLUME_PICOCURIE = "pCi/L"
 
 DEFAULT_SCAN_INTERVAL = 300
+
+ICONS: dict[str, str] = {"radioactive": "mdi:radioactive", "cloud": "mdi:cloud"}

--- a/homeassistant/components/airthings_ble/sensor.py
+++ b/homeassistant/components/airthings_ble/sensor.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
-from .const import DOMAIN, VOLUME_BECQUEREL, VOLUME_PICOCURIE
+from .const import DOMAIN, ICONS, VOLUME_BECQUEREL, VOLUME_PICOCURIE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,24 +41,24 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
         translation_key="radon_1day_avg",
         native_unit_of_measurement=VOLUME_BECQUEREL,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:radioactive",
+        icon=ICONS.get("radioactive"),
     ),
     "radon_longterm_avg": SensorEntityDescription(
         key="radon_longterm_avg",
         translation_key="radon_longterm_avg",
         native_unit_of_measurement=VOLUME_BECQUEREL,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:radioactive",
+        icon=ICONS.get("radioactive"),
     ),
     "radon_1day_level": SensorEntityDescription(
         key="radon_1day_level",
         translation_key="radon_1day_level",
-        icon="mdi:radioactive",
+        icon=ICONS.get("radioactive"),
     ),
     "radon_longterm_level": SensorEntityDescription(
         key="radon_longterm_level",
         translation_key="radon_longterm_level",
-        icon="mdi:radioactive",
+        icon=ICONS.get("radioactive"),
     ),
     "temperature": SensorEntityDescription(
         key="temperature",
@@ -96,7 +96,7 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
         native_unit_of_measurement=CONCENTRATION_PARTS_PER_BILLION,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:cloud",
+        icon=ICONS.get("cloud"),
     ),
     "illuminance": SensorEntityDescription(
         key="illuminance",

--- a/homeassistant/components/aussie_broadband/const.py
+++ b/homeassistant/components/aussie_broadband/const.py
@@ -3,3 +3,5 @@ DEFAULT_UPDATE_INTERVAL = 30
 DOMAIN = "aussie_broadband"
 SERVICE_ID = "service_id"
 CONF_SERVICES = "services"
+
+PHONE_ICON = "mdi:phone"

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, SERVICE_ID
+from .const import DOMAIN, PHONE_ICON, SERVICE_ID
 
 
 @dataclass
@@ -61,14 +61,14 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
         key="national",
         translation_key="national_calls",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        icon="mdi:phone",
+        icon=PHONE_ICON,
         value=lambda x: x.get("calls"),
     ),
     SensorValueEntityDescription(
         key="mobile",
         translation_key="mobile_calls",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        icon="mdi:phone",
+        icon=PHONE_ICON,
         value=lambda x: x.get("calls"),
     ),
     SensorValueEntityDescription(
@@ -100,7 +100,7 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
         translation_key="voicemail_calls",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        icon="mdi:phone",
+        icon=PHONE_ICON,
         value=lambda x: x.get("calls"),
     ),
     SensorValueEntityDescription(
@@ -108,7 +108,7 @@ SENSOR_DESCRIPTIONS: tuple[SensorValueEntityDescription, ...] = (
         translation_key="other_calls",
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
-        icon="mdi:phone",
+        icon=PHONE_ICON,
         value=lambda x: x.get("calls"),
     ),
     # Generic sensors

--- a/homeassistant/components/overkiz/button.py
+++ b/homeassistant/components/overkiz/button.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData
-from .const import DOMAIN, IGNORED_OVERKIZ_DEVICES
+from .const import DOMAIN, ICONS, IGNORED_OVERKIZ_DEVICES
 from .entity import OverkizDescriptiveEntity
 
 
@@ -29,47 +29,47 @@ BUTTON_DESCRIPTIONS: list[OverkizButtonDescription] = [
     OverkizButtonDescription(
         key="my",
         name="My position",
-        icon="mdi:star",
+        icon=ICONS.get("star"),
     ),
     # Identify
     OverkizButtonDescription(
         key="identify",  # startIdentify and identify are reversed... Swap this when fixed in API.
         name="Start identify",
-        icon="mdi:human-greeting-variant",
+        icon=ICONS.get("human-greeting"),
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     OverkizButtonDescription(
         key="stopIdentify",
         name="Stop identify",
-        icon="mdi:human-greeting-variant",
+        icon=ICONS.get("human-greeting"),
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
     OverkizButtonDescription(
         key="startIdentify",  # startIdentify and identify are reversed... Swap this when fixed in API.
         name="Identify",
-        icon="mdi:human-greeting-variant",
+        icon=ICONS.get("human-greeting"),
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     # RTDIndoorSiren / RTDOutdoorSiren
-    OverkizButtonDescription(key="dingDong", name="Ding dong", icon="mdi:bell-ring"),
-    OverkizButtonDescription(key="bip", name="Bip", icon="mdi:bell-ring"),
+    OverkizButtonDescription(key="dingDong", name="Ding dong", icon=ICONS.get("bell")),
+    OverkizButtonDescription(key="bip", name="Bip", icon=ICONS.get("bell")),
     OverkizButtonDescription(
-        key="fastBipSequence", name="Fast bip sequence", icon="mdi:bell-ring"
+        key="fastBipSequence", name="Fast bip sequence", icon=ICONS.get("bell")
     ),
-    OverkizButtonDescription(key="ring", name="Ring", icon="mdi:bell-ring"),
+    OverkizButtonDescription(key="ring", name="Ring", icon=ICONS.get("bell")),
     # DynamicScreen (ogp:blind) uses goToAlias (id 1: favorite1) instead of 'my'
     OverkizButtonDescription(
         key="goToAlias",
         press_args="1",
         name="My position",
-        icon="mdi:star",
+        icon=ICONS.get("star"),
     ),
     OverkizButtonDescription(
         key=OverkizCommand.CYCLE,
         name="Toggle",
-        icon="mdi:sync",
+        icon=ICONS.get("sync"),
     ),
 ]
 

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -157,3 +157,10 @@ OVERKIZ_UNIT_TO_HA: dict[str, str] = {
     MeasuredValueType.VOLUME_IN_GALLON: UnitOfVolume.GALLONS,
     MeasuredValueType.VOLUME_IN_LITER: UnitOfVolume.LITERS,
 }
+
+ICONS: dict[str, str] = {
+    "star": "mdi:star",
+    "human-greeting": "mdi:human-greeting-variant",
+    "bell": "mdi:bell-ring",
+    "sync": "mdi:sync",
+}

--- a/homeassistant/components/peco/const.py
+++ b/homeassistant/components/peco/const.py
@@ -17,3 +17,4 @@ CONFIG_FLOW_COUNTIES: Final = [{county: county.capitalize()} for county in COUNT
 SCAN_INTERVAL: Final = 9
 CONF_COUNTY: Final = "county"
 ATTR_CONTENT: Final = "content"
+ICONS: dict[str, str] = {"plug-off": "mdi:power-plug-off", "alert": "mdi:alert"}

--- a/homeassistant/components/peco/sensor.py
+++ b/homeassistant/components/peco/sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from . import PECOCoordinatorData
-from .const import ATTR_CONTENT, CONF_COUNTY, DOMAIN
+from .const import ATTR_CONTENT, CONF_COUNTY, DOMAIN, ICONS
 
 
 @dataclass
@@ -46,7 +46,7 @@ SENSOR_LIST: tuple[PECOSensorEntityDescription, ...] = (
         translation_key="customers_out",
         value_fn=lambda data: int(data.outages.customers_out),
         attribute_fn=lambda data: {},
-        icon="mdi:power-plug-off",
+        icon=ICONS.get("plug-off"),
         state_class=SensorStateClass.MEASUREMENT,
     ),
     PECOSensorEntityDescription(
@@ -55,7 +55,7 @@ SENSOR_LIST: tuple[PECOSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda data: int(data.outages.percent_customers_out),
         attribute_fn=lambda data: {},
-        icon="mdi:power-plug-off",
+        icon=ICONS.get("plug-off"),
         state_class=SensorStateClass.MEASUREMENT,
     ),
     PECOSensorEntityDescription(
@@ -63,7 +63,7 @@ SENSOR_LIST: tuple[PECOSensorEntityDescription, ...] = (
         translation_key="outage_count",
         value_fn=lambda data: int(data.outages.outage_count),
         attribute_fn=lambda data: {},
-        icon="mdi:power-plug-off",
+        icon=ICONS.get("plug-off"),
         state_class=SensorStateClass.MEASUREMENT,
     ),
     PECOSensorEntityDescription(
@@ -71,7 +71,7 @@ SENSOR_LIST: tuple[PECOSensorEntityDescription, ...] = (
         translation_key="customers_served",
         value_fn=lambda data: int(data.outages.customers_served),
         attribute_fn=lambda data: {},
-        icon="mdi:power-plug-off",
+        icon=ICONS.get("plug-off"),
         state_class=SensorStateClass.MEASUREMENT,
     ),
     PECOSensorEntityDescription(
@@ -79,7 +79,7 @@ SENSOR_LIST: tuple[PECOSensorEntityDescription, ...] = (
         translation_key="map_alert",
         value_fn=lambda data: str(data.alerts.alert_title),
         attribute_fn=lambda data: {ATTR_CONTENT: data.alerts.alert_content},
-        icon="mdi:alert",
+        icon=ICONS.get("alert"),
     ),
 )
 

--- a/homeassistant/components/pi_hole/const.py
+++ b/homeassistant/components/pi_hole/const.py
@@ -19,3 +19,5 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 DATA_KEY_API = "api"
 DATA_KEY_COORDINATOR = "coordinator"
+
+ICON_COMMENT_QUESTION_OUTLINE = "mdi:comment-question-outline"

--- a/homeassistant/components/pi_hole/sensor.py
+++ b/homeassistant/components/pi_hole/sensor.py
@@ -12,7 +12,12 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import PiHoleEntity
-from .const import DATA_KEY_API, DATA_KEY_COORDINATOR, DOMAIN as PIHOLE_DOMAIN
+from .const import (
+    DATA_KEY_API,
+    DATA_KEY_COORDINATOR,
+    DOMAIN as PIHOLE_DOMAIN,
+    ICON_COMMENT_QUESTION_OUTLINE,
+)
 
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
@@ -37,7 +42,7 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="dns_queries_today",
         translation_key="dns_queries_today",
         native_unit_of_measurement="queries",
-        icon="mdi:comment-question-outline",
+        icon=ICON_COMMENT_QUESTION_OUTLINE,
     ),
     SensorEntityDescription(
         key="domains_being_blocked",
@@ -49,13 +54,13 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="queries_cached",
         translation_key="queries_cached",
         native_unit_of_measurement="queries",
-        icon="mdi:comment-question-outline",
+        icon=ICON_COMMENT_QUESTION_OUTLINE,
     ),
     SensorEntityDescription(
         key="queries_forwarded",
         translation_key="queries_forwarded",
         native_unit_of_measurement="queries",
-        icon="mdi:comment-question-outline",
+        icon=ICON_COMMENT_QUESTION_OUTLINE,
     ),
     SensorEntityDescription(
         key="unique_clients",

--- a/homeassistant/components/poolsense/const.py
+++ b/homeassistant/components/poolsense/const.py
@@ -2,3 +2,4 @@
 
 DOMAIN = "poolsense"
 ATTRIBUTION = "PoolSense Data"
+POOL_ICON = "mdi:pool"

--- a/homeassistant/components/poolsense/sensor.py
+++ b/homeassistant/components/poolsense/sensor.py
@@ -17,19 +17,19 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import PoolSenseEntity
-from .const import DOMAIN
+from .const import DOMAIN, POOL_ICON
 
 SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="Chlorine",
         translation_key="chlorine",
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
-        icon="mdi:pool",
+        icon=POOL_ICON,
     ),
     SensorEntityDescription(
         key="pH",
         translation_key="ph",
-        icon="mdi:pool",
+        icon=POOL_ICON,
     ),
     SensorEntityDescription(
         key="Battery",
@@ -52,23 +52,23 @@ SENSOR_TYPES: tuple[SensorEntityDescription, ...] = (
         key="Chlorine High",
         translation_key="chlorine_high",
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
-        icon="mdi:pool",
+        icon=POOL_ICON,
     ),
     SensorEntityDescription(
         key="Chlorine Low",
         translation_key="chlorine_low",
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
-        icon="mdi:pool",
+        icon=POOL_ICON,
     ),
     SensorEntityDescription(
         key="pH High",
         translation_key="ph_high",
-        icon="mdi:pool",
+        icon=POOL_ICON,
     ),
     SensorEntityDescription(
         key="pH Low",
         translation_key="ph_low",
-        icon="mdi:pool",
+        icon=POOL_ICON,
     ),
 )
 

--- a/homeassistant/components/purpleair/const.py
+++ b/homeassistant/components/purpleair/const.py
@@ -8,3 +8,5 @@ LOGGER = logging.getLogger(__package__)
 CONF_READ_KEY = "read_key"
 CONF_SENSOR_INDICES = "sensor_indices"
 CONF_SHOW_ON_MAP = "show_on_map"
+
+ICON_BLUR = "mdi:blur"

--- a/homeassistant/components/purpleair/sensor.py
+++ b/homeassistant/components/purpleair/sensor.py
@@ -27,7 +27,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import PurpleAirEntity
-from .const import CONF_SENSOR_INDICES, DOMAIN
+from .const import CONF_SENSOR_INDICES, DOMAIN, ICON_BLUR
 from .coordinator import PurpleAirDataUpdateCoordinator
 
 CONCENTRATION_PARTICLES_PER_100_MILLILITERS = f"particles/100{UnitOfVolume.MILLILITERS}"
@@ -59,7 +59,7 @@ SENSOR_DESCRIPTIONS = [
         key="pm0.3_count_concentration",
         translation_key="pm0_3_count_concentration",
         entity_registry_enabled_default=False,
-        icon="mdi:blur",
+        icon=ICON_BLUR,
         native_unit_of_measurement=CONCENTRATION_PARTICLES_PER_100_MILLILITERS,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda sensor: sensor.pm0_3_um_count,
@@ -68,7 +68,7 @@ SENSOR_DESCRIPTIONS = [
         key="pm0.5_count_concentration",
         translation_key="pm0_5_count_concentration",
         entity_registry_enabled_default=False,
-        icon="mdi:blur",
+        icon=ICON_BLUR,
         native_unit_of_measurement=CONCENTRATION_PARTICLES_PER_100_MILLILITERS,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda sensor: sensor.pm0_5_um_count,
@@ -77,7 +77,7 @@ SENSOR_DESCRIPTIONS = [
         key="pm1.0_count_concentration",
         translation_key="pm1_0_count_concentration",
         entity_registry_enabled_default=False,
-        icon="mdi:blur",
+        icon=ICON_BLUR,
         native_unit_of_measurement=CONCENTRATION_PARTICLES_PER_100_MILLILITERS,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda sensor: sensor.pm1_0_um_count,
@@ -93,7 +93,7 @@ SENSOR_DESCRIPTIONS = [
         key="pm10.0_count_concentration",
         translation_key="pm10_0_count_concentration",
         entity_registry_enabled_default=False,
-        icon="mdi:blur",
+        icon=ICON_BLUR,
         native_unit_of_measurement=CONCENTRATION_PARTICLES_PER_100_MILLILITERS,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda sensor: sensor.pm10_0_um_count,
@@ -109,7 +109,7 @@ SENSOR_DESCRIPTIONS = [
         key="pm2.5_count_concentration",
         translation_key="pm2_5_count_concentration",
         entity_registry_enabled_default=False,
-        icon="mdi:blur",
+        icon=ICON_BLUR,
         native_unit_of_measurement=CONCENTRATION_PARTICLES_PER_100_MILLILITERS,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda sensor: sensor.pm2_5_um_count,
@@ -125,7 +125,7 @@ SENSOR_DESCRIPTIONS = [
         key="pm5.0_count_concentration",
         translation_key="pm5_0_count_concentration",
         entity_registry_enabled_default=False,
-        icon="mdi:blur",
+        icon=ICON_BLUR,
         native_unit_of_measurement=CONCENTRATION_PARTICLES_PER_100_MILLILITERS,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda sensor: sensor.pm5_0_um_count,

--- a/homeassistant/components/qnap/const.py
+++ b/homeassistant/components/qnap/const.py
@@ -10,3 +10,9 @@ DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
 DOMAIN = "qnap"
+
+ICONS: dict[str, str] = {
+    "checkbox-marked": "mdi:checkbox-marked-circle-outline",
+    "memory": "mdi:memory",
+    "pie-chart": "mdi:chart-pie",
+}

--- a/homeassistant/components/qnap/sensor.py
+++ b/homeassistant/components/qnap/sensor.py
@@ -44,6 +44,7 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
     DOMAIN,
+    ICONS,
 )
 from .coordinator import QnapCoordinator
 
@@ -68,7 +69,7 @@ _SYSTEM_MON_COND: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="status",
         name="Status",
-        icon="mdi:checkbox-marked-circle-outline",
+        icon=ICONS.get("checkbox-marked"),
     ),
     SensorEntityDescription(
         key="system_temp",
@@ -85,7 +86,7 @@ _CPU_MON_COND: tuple[SensorEntityDescription, ...] = (
         name="CPU Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
-        icon="mdi:checkbox-marked-circle-outline",
+        icon=ICONS.get("checkbox-marked"),
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -104,7 +105,7 @@ _MEMORY_MON_COND: tuple[SensorEntityDescription, ...] = (
         name="Memory Available",
         native_unit_of_measurement=UnitOfInformation.MEBIBYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
-        icon="mdi:memory",
+        icon=ICONS.get("memory"),
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
@@ -115,7 +116,7 @@ _MEMORY_MON_COND: tuple[SensorEntityDescription, ...] = (
         name="Memory Used",
         native_unit_of_measurement=UnitOfInformation.MEBIBYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
-        icon="mdi:memory",
+        icon=ICONS.get("memory"),
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
@@ -125,7 +126,7 @@ _MEMORY_MON_COND: tuple[SensorEntityDescription, ...] = (
         key="memory_percent_used",
         name="Memory Usage",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:memory",
+        icon=ICONS.get("memory"),
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
     ),
@@ -134,7 +135,7 @@ _NETWORK_MON_COND: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="network_link_status",
         name="Network Link",
-        icon="mdi:checkbox-marked-circle-outline",
+        icon=ICONS.get("checkbox-marked"),
     ),
     SensorEntityDescription(
         key="network_tx",
@@ -163,7 +164,7 @@ _DRIVE_MON_COND: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="drive_smart_status",
         name="SMART Status",
-        icon="mdi:checkbox-marked-circle-outline",
+        icon=ICONS.get("checkbox-marked"),
         entity_registry_enabled_default=False,
     ),
     SensorEntityDescription(
@@ -182,7 +183,7 @@ _VOLUME_MON_COND: tuple[SensorEntityDescription, ...] = (
         name="Used Space",
         native_unit_of_measurement=UnitOfInformation.BYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
-        icon="mdi:chart-pie",
+        icon=ICONS.get("pie-chart"),
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
@@ -193,7 +194,7 @@ _VOLUME_MON_COND: tuple[SensorEntityDescription, ...] = (
         name="Free Space",
         native_unit_of_measurement=UnitOfInformation.BYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
-        icon="mdi:chart-pie",
+        icon=ICONS.get("pie-chart"),
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
@@ -203,7 +204,7 @@ _VOLUME_MON_COND: tuple[SensorEntityDescription, ...] = (
         key="volume_percentage_used",
         name="Volume Used",
         native_unit_of_measurement=PERCENTAGE,
-        icon="mdi:chart-pie",
+        icon=ICONS.get("pie-chart"),
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=0,
     ),

--- a/homeassistant/components/qnap_qsw/const.py
+++ b/homeassistant/components/qnap_qsw/const.py
@@ -15,3 +15,9 @@ QSW_COORD_FW: Final = "coordinator-firmware"
 QSW_REBOOT = "reboot"
 QSW_TIMEOUT_SEC: Final = 25
 QSW_UPDATE: Final = "update"
+
+ICONS: dict[str, str] = {
+    "download-network": "mdi:download-network",
+    "close-network": "mdi:close-network",
+    "upload-network": "mdi:upload-network",
+}

--- a/homeassistant/components/qnap_qsw/sensor.py
+++ b/homeassistant/components/qnap_qsw/sensor.py
@@ -45,7 +45,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED
 
-from .const import ATTR_MAX, DOMAIN, QSW_COORD_DATA, RPM
+from .const import ATTR_MAX, DOMAIN, ICONS, QSW_COORD_DATA, RPM
 from .coordinator import QswDataCoordinator
 from .entity import QswEntityDescription, QswEntityType, QswSensorEntity
 
@@ -91,7 +91,7 @@ SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
         entity_registry_enabled_default=False,
         translation_key="rx",
         device_class=SensorDeviceClass.DATA_SIZE,
-        icon="mdi:download-network",
+        icon=ICONS.get("download-network"),
         key=QSD_PORTS_STATISTICS,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -100,7 +100,7 @@ SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     QswSensorEntityDescription(
         entity_registry_enabled_default=False,
         translation_key="rx_errors",
-        icon="mdi:close-network",
+        icon=ICONS.get("close-network"),
         key=QSD_PORTS_STATISTICS,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -110,7 +110,7 @@ SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
         entity_registry_enabled_default=False,
         translation_key="rx_speed",
         device_class=SensorDeviceClass.DATA_RATE,
-        icon="mdi:download-network",
+        icon=ICONS.get("download-network"),
         key=QSD_PORTS_STATISTICS,
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
@@ -130,7 +130,7 @@ SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
         entity_registry_enabled_default=False,
         translation_key="tx",
         device_class=SensorDeviceClass.DATA_SIZE,
-        icon="mdi:upload-network",
+        icon=ICONS.get("upload-network"),
         key=QSD_PORTS_STATISTICS,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -140,7 +140,7 @@ SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
         entity_registry_enabled_default=False,
         translation_key="tx_speed",
         device_class=SensorDeviceClass.DATA_RATE,
-        icon="mdi:upload-network",
+        icon=ICONS.get("upload-network"),
         key=QSD_PORTS_STATISTICS,
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
@@ -171,7 +171,7 @@ LACP_PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     ),
     QswSensorEntityDescription(
         entity_registry_enabled_default=False,
-        icon="mdi:download-network",
+        icon=ICONS.get("download-network"),
         key=QSD_PORTS_STATISTICS,
         name="RX",
         native_unit_of_measurement=UnitOfInformation.BYTES,
@@ -181,7 +181,7 @@ LACP_PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     ),
     QswSensorEntityDescription(
         entity_registry_enabled_default=False,
-        icon="mdi:close-network",
+        icon=ICONS.get("close-network"),
         key=QSD_PORTS_STATISTICS,
         entity_category=EntityCategory.DIAGNOSTIC,
         name="RX Errors",
@@ -192,7 +192,7 @@ LACP_PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     QswSensorEntityDescription(
         device_class=SensorDeviceClass.DATA_RATE,
         entity_registry_enabled_default=False,
-        icon="mdi:download-network",
+        icon=ICONS.get("download-network"),
         key=QSD_PORTS_STATISTICS,
         name="RX Speed",
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
@@ -202,7 +202,7 @@ LACP_PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     ),
     QswSensorEntityDescription(
         entity_registry_enabled_default=False,
-        icon="mdi:upload-network",
+        icon=ICONS.get("upload-network"),
         key=QSD_PORTS_STATISTICS,
         name="TX",
         native_unit_of_measurement=UnitOfInformation.BYTES,
@@ -213,7 +213,7 @@ LACP_PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     QswSensorEntityDescription(
         device_class=SensorDeviceClass.DATA_RATE,
         entity_registry_enabled_default=False,
-        icon="mdi:upload-network",
+        icon=ICONS.get("upload-network"),
         key=QSD_PORTS_STATISTICS,
         name="TX Speed",
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
@@ -237,7 +237,7 @@ PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     ),
     QswSensorEntityDescription(
         entity_registry_enabled_default=False,
-        icon="mdi:download-network",
+        icon=ICONS.get("download-network"),
         key=QSD_PORTS_STATISTICS,
         name="RX",
         native_unit_of_measurement=UnitOfInformation.BYTES,
@@ -247,7 +247,7 @@ PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     ),
     QswSensorEntityDescription(
         entity_registry_enabled_default=False,
-        icon="mdi:close-network",
+        icon=ICONS.get("close-network"),
         key=QSD_PORTS_STATISTICS,
         entity_category=EntityCategory.DIAGNOSTIC,
         name="RX Errors",
@@ -258,7 +258,7 @@ PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     QswSensorEntityDescription(
         device_class=SensorDeviceClass.DATA_RATE,
         entity_registry_enabled_default=False,
-        icon="mdi:download-network",
+        icon=ICONS.get("download-network"),
         key=QSD_PORTS_STATISTICS,
         name="RX Speed",
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
@@ -268,7 +268,7 @@ PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     ),
     QswSensorEntityDescription(
         entity_registry_enabled_default=False,
-        icon="mdi:upload-network",
+        icon=ICONS.get("upload-network"),
         key=QSD_PORTS_STATISTICS,
         name="TX",
         native_unit_of_measurement=UnitOfInformation.BYTES,
@@ -279,7 +279,7 @@ PORT_SENSOR_TYPES: Final[tuple[QswSensorEntityDescription, ...]] = (
     QswSensorEntityDescription(
         device_class=SensorDeviceClass.DATA_RATE,
         entity_registry_enabled_default=False,
-        icon="mdi:upload-network",
+        icon=ICONS.get("upload-network"),
         key=QSD_PORTS_STATISTICS,
         name="TX Speed",
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,

--- a/homeassistant/components/rainmachine/binary_sensor.py
+++ b/homeassistant/components/rainmachine/binary_sensor.py
@@ -12,7 +12,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RainMachineData, RainMachineEntity
-from .const import DATA_PROVISION_SETTINGS, DATA_RESTRICTIONS_CURRENT, DOMAIN
+from .const import (
+    DATA_PROVISION_SETTINGS,
+    DATA_RESTRICTIONS_CURRENT,
+    DOMAIN,
+    ICON_CANCEL,
+)
 from .model import (
     RainMachineEntityDescription,
     RainMachineEntityDescriptionMixinDataKey,
@@ -52,7 +57,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
     RainMachineBinarySensorDescription(
         key=TYPE_FREEZE,
         translation_key=TYPE_FREEZE,
-        icon="mdi:cancel",
+        icon=ICON_CANCEL,
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_CURRENT,
         data_key="freeze",
@@ -60,7 +65,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
     RainMachineBinarySensorDescription(
         key=TYPE_HOURLY,
         translation_key=TYPE_HOURLY,
-        icon="mdi:cancel",
+        icon=ICON_CANCEL,
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_CURRENT,
         data_key="hourly",
@@ -68,7 +73,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
     RainMachineBinarySensorDescription(
         key=TYPE_MONTH,
         translation_key=TYPE_MONTH,
-        icon="mdi:cancel",
+        icon=ICON_CANCEL,
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_CURRENT,
         data_key="month",
@@ -76,7 +81,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
     RainMachineBinarySensorDescription(
         key=TYPE_RAINDELAY,
         translation_key=TYPE_RAINDELAY,
-        icon="mdi:cancel",
+        icon=ICON_CANCEL,
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_CURRENT,
         data_key="rainDelay",
@@ -84,7 +89,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
     RainMachineBinarySensorDescription(
         key=TYPE_RAINSENSOR,
         translation_key=TYPE_RAINSENSOR,
-        icon="mdi:cancel",
+        icon=ICON_CANCEL,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         api_category=DATA_RESTRICTIONS_CURRENT,
@@ -93,7 +98,7 @@ BINARY_SENSOR_DESCRIPTIONS = (
     RainMachineBinarySensorDescription(
         key=TYPE_WEEKDAY,
         translation_key=TYPE_WEEKDAY,
-        icon="mdi:cancel",
+        icon=ICON_CANCEL,
         entity_category=EntityCategory.DIAGNOSTIC,
         api_category=DATA_RESTRICTIONS_CURRENT,
         data_key="weekDay",

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -16,6 +16,7 @@ DATA_PROVISION_SETTINGS = "provision.settings"
 DATA_RESTRICTIONS_CURRENT = "restrictions.current"
 DATA_RESTRICTIONS_UNIVERSAL = "restrictions.universal"
 DATA_ZONES = "zones"
+NOT_SET = "Not Set"
 
 DEFAULT_PORT = 8080
 DEFAULT_ZONE_RUN = 60 * 10

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -23,3 +23,4 @@ DEFAULT_ZONE_RUN = 60 * 10
 
 ICON_WATER_PUMP = "mdi:water-pump"
 ICON_PIPE_LEAK = "mdi:pipe-leak"
+ICON_CANCEL = "mdi:cancel"

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -20,3 +20,6 @@ NOT_SET = "Not Set"
 
 DEFAULT_PORT = 8080
 DEFAULT_ZONE_RUN = 60 * 10
+
+ICON_WATER_PUMP = "mdi:water-pump"
+ICON_PIPE_LEAK = "mdi:pipe-leak"

--- a/homeassistant/components/rainmachine/sensor.py
+++ b/homeassistant/components/rainmachine/sensor.py
@@ -20,7 +20,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utc_from_timestamp, utcnow
 
 from . import RainMachineData, RainMachineEntity
-from .const import DATA_PROGRAMS, DATA_PROVISION_SETTINGS, DATA_ZONES, DOMAIN
+from .const import (
+    DATA_PROGRAMS,
+    DATA_PROVISION_SETTINGS,
+    DATA_ZONES,
+    DOMAIN,
+    ICON_PIPE_LEAK,
+    ICON_WATER_PUMP,
+)
 from .model import (
     RainMachineEntityDescription,
     RainMachineEntityDescriptionMixinDataKey,
@@ -70,7 +77,7 @@ SENSOR_DESCRIPTIONS = (
     RainMachineSensorDataDescription(
         key=TYPE_FLOW_SENSOR_CLICK_M3,
         translation_key=TYPE_FLOW_SENSOR_CLICK_M3,
-        icon="mdi:water-pump",
+        icon=ICON_WATER_PUMP,
         native_unit_of_measurement=f"clicks/{UnitOfVolume.CUBIC_METERS}",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -81,7 +88,7 @@ SENSOR_DESCRIPTIONS = (
     RainMachineSensorDataDescription(
         key=TYPE_FLOW_SENSOR_CONSUMED_LITERS,
         translation_key=TYPE_FLOW_SENSOR_CONSUMED_LITERS,
-        icon="mdi:water-pump",
+        icon=ICON_WATER_PUMP,
         device_class=SensorDeviceClass.WATER,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfVolume.LITERS,
@@ -93,7 +100,7 @@ SENSOR_DESCRIPTIONS = (
     RainMachineSensorDataDescription(
         key=TYPE_FLOW_SENSOR_LEAK_CLICKS,
         translation_key=TYPE_FLOW_SENSOR_LEAK_CLICKS,
-        icon="mdi:pipe-leak",
+        icon=ICON_PIPE_LEAK,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement="clicks",
         entity_registry_enabled_default=False,
@@ -104,7 +111,7 @@ SENSOR_DESCRIPTIONS = (
     RainMachineSensorDataDescription(
         key=TYPE_FLOW_SENSOR_LEAK_VOLUME,
         translation_key=TYPE_FLOW_SENSOR_LEAK_VOLUME,
-        icon="mdi:pipe-leak",
+        icon=ICON_PIPE_LEAK,
         device_class=SensorDeviceClass.WATER,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfVolume.LITERS,
@@ -116,7 +123,7 @@ SENSOR_DESCRIPTIONS = (
     RainMachineSensorDataDescription(
         key=TYPE_FLOW_SENSOR_START_INDEX,
         translation_key=TYPE_FLOW_SENSOR_START_INDEX,
-        icon="mdi:water-pump",
+        icon=ICON_WATER_PUMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement="index",
         entity_registry_enabled_default=False,
@@ -126,7 +133,7 @@ SENSOR_DESCRIPTIONS = (
     RainMachineSensorDataDescription(
         key=TYPE_FLOW_SENSOR_WATERING_CLICKS,
         translation_key=TYPE_FLOW_SENSOR_WATERING_CLICKS,
-        icon="mdi:water-pump",
+        icon=ICON_WATER_PUMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement="clicks",
         entity_registry_enabled_default=False,
@@ -137,7 +144,7 @@ SENSOR_DESCRIPTIONS = (
     RainMachineSensorDataDescription(
         key=TYPE_LAST_LEAK_DETECTED,
         translation_key=TYPE_LAST_LEAK_DETECTED,
-        icon="mdi:pipe-leak",
+        icon=ICON_PIPE_LEAK,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         device_class=SensorDeviceClass.TIMESTAMP,

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -29,6 +29,7 @@ from .const import (
     DATA_ZONES,
     DEFAULT_ZONE_RUN,
     DOMAIN,
+    NOT_SET,
 )
 from .model import (
     RainMachineEntityDescription,
@@ -61,7 +62,7 @@ ATTR_ZONES = "zones"
 DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
 SOIL_TYPE_MAP = {
-    0: "Not Set",
+    0: NOT_SET,
     1: "Clay Loam",
     2: "Silty Clay",
     3: "Clay",
@@ -76,7 +77,7 @@ SOIL_TYPE_MAP = {
 }
 
 SLOPE_TYPE_MAP = {
-    0: "Not Set",
+    0: NOT_SET,
     1: "Flat",
     2: "Moderate",
     3: "High",
@@ -85,7 +86,7 @@ SLOPE_TYPE_MAP = {
 }
 
 SPRINKLER_TYPE_MAP = {
-    0: "Not Set",
+    0: NOT_SET,
     1: "Popup Spray",
     2: "Rotors Low Rate",
     3: "Surface Drip",
@@ -94,11 +95,11 @@ SPRINKLER_TYPE_MAP = {
     99: "Other",
 }
 
-SUN_EXPOSURE_MAP = {0: "Not Set", 1: "Full Sun", 2: "Partial Shade", 3: "Full Shade"}
+SUN_EXPOSURE_MAP = {0: NOT_SET, 1: "Full Sun", 2: "Partial Shade", 3: "Full Shade"}
 
 VEGETATION_MAP = {
-    0: "Not Set",
-    1: "Not Set",
+    0: NOT_SET,
+    1: NOT_SET,
     2: "Cool Season Grass",
     3: "Fruit Trees",
     4: "Flowers",

--- a/homeassistant/components/rfxtrx/const.py
+++ b/homeassistant/components/rfxtrx/const.py
@@ -46,3 +46,5 @@ EVENT_RFXTRX_EVENT = "rfxtrx_event"
 DATA_RFXOBJECT = "rfxobject"
 
 DOMAIN = "rfxtrx"
+
+SENSOR_STATUS = "Sensor Status"

--- a/homeassistant/components/rfxtrx/siren.py
+++ b/homeassistant/components/rfxtrx/siren.py
@@ -19,13 +19,11 @@ from . import (
     RfxtrxCommandEntity,
     async_setup_platform_entry,
 )
-from .const import CONF_OFF_DELAY
+from .const import CONF_OFF_DELAY, SENSOR_STATUS
 
 SECURITY_PANIC_ON = "Panic"
 SECURITY_PANIC_OFF = "End Panic"
 SECURITY_PANIC_ALL = {SECURITY_PANIC_ON, SECURITY_PANIC_OFF}
-
-SENSOR_STATUS = "Sensor Status"
 
 
 def supported(event: rfxtrxmod.RFXtrxEvent) -> bool:

--- a/homeassistant/components/rfxtrx/siren.py
+++ b/homeassistant/components/rfxtrx/siren.py
@@ -25,6 +25,8 @@ SECURITY_PANIC_ON = "Panic"
 SECURITY_PANIC_OFF = "End Panic"
 SECURITY_PANIC_ALL = {SECURITY_PANIC_ON, SECURITY_PANIC_OFF}
 
+SENSOR_STATUS = "Sensor Status"
+
 
 def supported(event: rfxtrxmod.RFXtrxEvent) -> bool:
     """Return whether an event supports sirens."""
@@ -36,7 +38,7 @@ def supported(event: rfxtrxmod.RFXtrxEvent) -> bool:
     if isinstance(device, rfxtrxmod.SecurityDevice) and isinstance(
         event, rfxtrxmod.SensorEvent
     ):
-        if event.values["Sensor Status"] in SECURITY_PANIC_ALL:
+        if event.values[SENSOR_STATUS] in SECURITY_PANIC_ALL:
             return True
 
     return False
@@ -76,7 +78,7 @@ async def async_setup_entry(
         if isinstance(device, rfxtrxmod.SecurityDevice) and isinstance(
             event, rfxtrxmod.SensorEvent
         ):
-            if event.values["Sensor Status"] in SECURITY_PANIC_ALL:
+            if event.values[SENSOR_STATUS] in SECURITY_PANIC_ALL:
                 return [
                     RfxtrxSecurityPanic(
                         event.device,
@@ -230,7 +232,7 @@ class RfxtrxSecurityPanic(RfxtrxCommandEntity, SirenEntity, RfxtrxOffDelayMixin)
         """Apply a received event."""
         super()._apply_event(event)
 
-        status = event.values.get("Sensor Status")
+        status = event.values.get(SENSOR_STATUS)
 
         if status == SECURITY_PANIC_ON:
             self._cancel_timeout()

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -37,16 +37,18 @@ DEFAULT_NAME = "RMV Journey"
 
 VALID_PRODUCTS = ["U-Bahn", "Tram", "Bus", "S", "RB", "RE", "EC", "IC", "ICE"]
 
+MDI = "mdi:train"
+
 ICONS = {
     "U-Bahn": "mdi:subway",
     "Tram": "mdi:tram",
     "Bus": "mdi:bus",
-    "S": "mdi:train",
-    "RB": "mdi:train",
-    "RE": "mdi:train",
-    "EC": "mdi:train",
-    "IC": "mdi:train",
-    "ICE": "mdi:train",
+    "S": MDI,
+    "RB": MDI,
+    "RE": MDI,
+    "EC": MDI,
+    "IC": MDI,
+    "ICE": MDI,
     "SEV": "mdi:checkbox-blank-circle-outline",
     None: "mdi:clock",
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Second try. Apologies for the last pull requests, it seems like our fork was more up to date to the Home Assistant repo, we're unsure why this happened. Hopefully everything works as intended this time.

This PR contains fixes for code smells of the type 'String literals should not be duplicated'.

Duplicate string literals scattered throughout the codebase make it harder to maintain the software. If a string value needs to be changed, developers must remember to update all occurrences of that string, which is error-prone and time-consuming. This can lead to inconsistencies and bugs in the code.

## Addressed by:
Unique string literals were added to the const.py file as variables and then used in the corresponding files.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
