### PR TITLE
World clock feature implementation

### DIFF
--- a/homeassistant/components/worldclock/sensor.py
+++ b/homeassistant/components/worldclock/sensor.py
@@ -1,7 +1,8 @@
-"""Support for showing the time in a different time zone."""
+"""Support for showing the time and places in multiple time zones."""
 from __future__ import annotations
 
 from datetime import tzinfo
+from typing import Optional
 
 import voluptuous as vol
 
@@ -12,8 +13,22 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
+from homeassistant.helpers.event import async_track_state_change
 
+import pytz
+from datetime import datetime
+
+from pytz import timezone as tz
+import smtplib
+from email.mime.text import MIMEText
+
+CONF_SECOND_TIME_ZONE = "second_time_zone"
+CONF_FIRST_CITY_NAME = "first_city_name"
+CONF_SECOND_CITY_NAME = "second_city_name"
 CONF_TIME_FORMAT = "time_format"
+CONF_SENDER = "sender"
+CONF_RECEIVER = "receiver"
+CONF_PASSWORD = "password"
 
 DEFAULT_NAME = "Worldclock Sensor"
 DEFAULT_TIME_STR_FORMAT = "%H:%M"
@@ -21,8 +36,14 @@ DEFAULT_TIME_STR_FORMAT = "%H:%M"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_TIME_ZONE): cv.time_zone,
+        vol.Required(CONF_SECOND_TIME_ZONE): cv.time_zone,
+        vol.Optional(CONF_FIRST_CITY_NAME): cv.string,
+        vol.Optional(CONF_SECOND_CITY_NAME): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_TIME_FORMAT, default=DEFAULT_TIME_STR_FORMAT): cv.string,
+        vol.Optional(CONF_SENDER): cv.string,
+        vol.Optional(CONF_RECEIVER): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
     }
 )
 
@@ -35,12 +56,82 @@ async def async_setup_platform(
 ) -> None:
     """Set up the World clock sensor."""
     time_zone = dt_util.get_time_zone(config[CONF_TIME_ZONE])
+
+    # Retrieve the selected time from input_datetime.custom_time_secondary_zone
+    selected_time_entity_id = "input_datetime.custom_time_secondary_zone"
+    selected_time_state = hass.states.get(selected_time_entity_id)
+    selected_time = selected_time_state.state
+
+    # Extract hours and minutes from the selected time
+    time_string = selected_time
+    time_list = [int(x) for x in time_string.split(":")]
+    h1 = time_list[0]
+    m1 = time_list[1]
+
+    # Retrieve email notification configuration
+    sender = config.get(CONF_SENDER)
+    receiver = config.get(CONF_RECEIVER)
+    password = config.get(CONF_PASSWORD)
+
+    # Initial setup
+    await update_sensor(
+        hass, time_zone, config, async_add_entities, h1, m1, sender, receiver, password
+    )
+
+    # Register callback for future updates
+    async_track_state_change(
+        hass,
+        selected_time_entity_id,
+        lambda entity_id, old_state, new_state: hass.async_create_task(
+            update_sensor(
+                hass,
+                time_zone,
+                config,
+                async_add_entities,
+                h1,
+                m1,
+                sender,
+                receiver,
+                password,
+            )
+        ),
+    )
+
+
+async def update_sensor(
+    hass: HomeAssistant,
+    time_zone,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    h1: int,
+    m1: int,
+    sender: str,
+    receiver: str,
+    password: str,
+) -> None:
+    """Update the World clock sensor."""
+    selected_secondary_time_zone = hass.states.get(
+        "input_select.world_clock_secondary_time_zone"
+    ).state
+    second_time_zone = dt_util.get_time_zone(selected_secondary_time_zone)
+
+    first_city_name = config.get(CONF_FIRST_CITY_NAME)
+    second_city_name = config.get(CONF_SECOND_CITY_NAME)
+
     async_add_entities(
         [
             WorldClockSensor(
                 time_zone,
+                second_time_zone,
+                first_city_name,
+                second_city_name,
                 config[CONF_NAME],
                 config[CONF_TIME_FORMAT],
+                h1,
+                m1,
+                sender,
+                receiver,
+                password,
             )
         ],
         True,
@@ -52,14 +143,77 @@ class WorldClockSensor(SensorEntity):
 
     _attr_icon = "mdi:clock"
 
-    def __init__(self, time_zone: tzinfo | None, name: str, time_format: str) -> None:
+    def __init__(
+        self,
+        time_zone: tzinfo | None,
+        second_time_zone: tzinfo | None,
+        first_city_name: str | None,
+        second_city_name: str | None,
+        name: str,
+        time_format: str,
+        h1: int,
+        m1: int,
+        sender: str,
+        receiver: str,
+        password: str,
+    ) -> None:
         """Initialize the sensor."""
         self._attr_name = name
         self._time_zone = time_zone
+        self._second_time_zone = second_time_zone
+        self._first_city_name = first_city_name
+        self._second_city_name = second_city_name
         self._time_format = time_format
+        self._h1 = h1
+        self._m1 = m1
+        self._sender = sender
+        self._receiver = receiver
+        self._password = password
 
     async def async_update(self) -> None:
-        """Get the time and updates the states."""
-        self._attr_native_value = dt_util.now(time_zone=self._time_zone).strftime(
-            self._time_format
+        """Get the time and update the states."""
+        current_time = dt_util.now(time_zone=self._time_zone)
+        second_time = dt_util.now(time_zone=self._second_time_zone)
+        first_city_display = (
+            f"{self._first_city_name}: {current_time.strftime(self._time_format)}"
+            if self._first_city_name
+            else current_time.strftime(self._time_format)
         )
+        second_city_display = (
+            f"{self._second_city_name}: {second_time.strftime(self._time_format)}"
+            if self._second_city_name
+            else second_time.strftime(self._time_format)
+        )
+
+        self._attr_native_value = f"{first_city_display} / {second_city_display}"
+
+        # Access the stored values of hours and minutes
+        h1 = self._h1
+        m1 = self._m1
+        secondary_time_zone = self._second_time_zone
+
+        off_shore_time = second_time.time()
+        hours = off_shore_time.hour
+        minutes = off_shore_time.minute
+
+        if (hours == h1) and (minutes == m1):
+            # retrieving credentials:
+            sender = self._sender
+            receiver = self._receiver
+            password = self._password
+            # Your email notification logic goes here
+            sub = "Notification from homeassistant"
+            msg = f"a reminder from homeassistant to check your work, ir is {h1}:{m1} at {secondary_time_zone}"
+            try:
+                server = smtplib.SMTP("smtp.outlook.com", 587)
+                server.starttls()
+                server.login(sender, password)
+                msg = MIMEText(msg)
+                msg["Subject"] = sub
+                msg["From"] = sender
+                msg["To"] = receiver
+                msg.set_param("importance", "high value")
+                server.sendmail(sender, receiver, msg.as_string())
+                print(f"email to {receiver} has been sent")
+            except:
+                print("there is some problem in sending emails. Please try again")

--- a/homeassistant/components/worldclock/test.py
+++ b/homeassistant/components/worldclock/test.py
@@ -1,0 +1,123 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+from pytz import timezone as tz
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util.dt import now
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.entity_platform import EntityPlatform
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from ..worldclock.sensor import WorldClockSensor, async_setup_platform, update_sensor
+
+
+class TestWorldClockSensor(unittest.TestCase):
+    def setUp(self):
+        self.hass = MagicMock(spec=HomeAssistant)
+        self.config = {
+            "time_zone": "America/New_York",
+            "second_time_zone": "Europe/London",
+            "first_city_name": "New York",
+            "second_city_name": "London",
+            "name": "World Clock",
+            "time_format": "%H:%M",
+            "sender": "test@example.com",
+            "receiver": "test@example.com",
+            "password": "password",
+        }
+        self.add_entities = MagicMock()
+        self.h1 = 10
+        self.m1 = 30
+
+    @patch(
+        "homeassistant.components.worldclock.sensor.dt_util.now",
+        return_value=datetime(2022, 1, 1, 10, 30, tzinfo=tz("America/New_York")),
+    )
+    @patch(
+        "homeassistant.components.worldclock.sensor.dt_util.get_time_zone",
+        return_value=tz("America/New_York"),
+    )
+    @patch(
+        "homeassistant.components.worldclock.sensor.async_track_state_change",
+        return_value=None,
+    )
+    @patch(
+        "homeassistant.components.worldclock.sensor.hass.states.get",
+        return_value=MagicMock(state="10:30"),
+    )
+    async def test_async_setup_platform(
+        self,
+        mock_hass_states_get,
+        mock_async_track_state_change,
+        mock_get_time_zone,
+        mock_now,
+    ):
+        await async_setup_platform(
+            self.hass, self.config, self.add_entities, discovery_info=None
+        )
+        self.add_entities.assert_called_once()
+
+    @patch(
+        "homeassistant.components.worldclock.sensor.dt_util.now",
+        return_value=datetime(2022, 1, 1, 10, 30, tzinfo=tz("America/New_York")),
+    )
+    @patch(
+        "homeassistant.components.worldclock.sensor.dt_util.get_time_zone",
+        return_value=tz("America/New_York"),
+    )
+    @patch(
+        "homeassistant.components.worldclock.sensor.async_track_state_change",
+        return_value=None,
+    )
+    @patch(
+        "homeassistant.components.worldclock.sensor.hass.states.get",
+        return_value=MagicMock(state="10:30"),
+    )
+    async def test_update_sensor(
+        self,
+        mock_hass_states_get,
+        mock_async_track_state_change,
+        mock_get_time_zone,
+        mock_now,
+    ):
+        await update_sensor(
+            self.hass,
+            tz("America/New_York"),
+            self.config,
+            self.add_entities,
+            self.h1,
+            self.m1,
+            self.config["sender"],
+            self.config["receiver"],
+            self.config["password"],
+        )
+        self.add_entities.assert_called_once()
+
+    @patch(
+        "homeassistant.components.worldclock.sensor.dt_util.now",
+        return_value=datetime(2022, 1, 1, 10, 30, tzinfo=tz("America/New_York")),
+    )
+    @patch(
+        "homeassistant.components.worldclock.sensor.dt_util.get_time_zone",
+        return_value=tz("America/New_York"),
+    )
+    def test_world_clock_sensor(self, mock_get_time_zone, mock_now):
+        sensor = WorldClockSensor(
+            tz("America/New_York"),
+            tz("Europe/London"),
+            "New York",
+            "London",
+            "World Clock",
+            "%H:%M",
+            self.h1,
+            self.m1,
+            self.config["sender"],
+            self.config["receiver"],
+            self.config["password"],
+        )
+        sensor.async_update()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Group 5

In feature implementation, the integration displays the time for multiple time zones, It also displays a section where the user can change the time zone and a section where the user can give a custom time to receive alert (E-mail)

the following script must be added to configuration.yaml file for adding the integration:

sensor:
  - platform: worldclock
    time_zone: Europe/Stockholm
    second_time_zone: Australia/Sydney
    first_city_name: Stockholm
    second_city_name: selected time zone
    sender: "sender@outlook.com"
    receiver: "email@example.com" # please change the following email for testing and debugging
    password: "sender's_password"



input_select:
  world_clock_secondary_time_zone:
    name: Select Secondary Time Zone
    options:
      - Europe/London
      - America/New_York
      - Australia/Sydney
      # Add more time zones as needed


input_datetime:
  custom_time_secondary_zone:
    name: Time to receive notifications
    has_date: false
    has_time: true


The following script must be added to automations.yaml before adding the integration:

- id: notify_timezone_change
  alias: Notify Timezone Change
  trigger:
    platform: state
    entity_id: input_select.world_clock_secondary_time_zone
  action:
    - service: persistent_notification.create
      data:
        title: "Timezone Change"
        message: "The secondary time zone has been updated. Please restart Home Assistant (from the compiler (vscode))."

- id: notify_time_update
  alias: Notify Time Update
  trigger:
    platform: state
    entity_id: input_datetime.custom_time_secondary_zone
  action:
    - service: persistent_notification.create
      data:
        title: "Notification Time Update"
        message: "The notification time has been updated. Please restart Home Assistant."

