### PR TITLE
Group 10 Speedtest integration feature implementation

### DIFF
--- a/homeassistant/components/speedtestdotnet/config_flow.py
+++ b/homeassistant/components/speedtestdotnet/config_flow.py
@@ -10,6 +10,8 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
+    CONF_PAID_DOWNLOAD_SPEED,
+    CONF_PAID_UPLOAD_SPEED,
     CONF_SERVER_ID,
     CONF_SERVER_NAME,
     DEFAULT_NAME,
@@ -39,7 +41,19 @@ class SpeedTestFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         if user_input is None:
-            return self.async_show_form(step_id="user")
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_PAID_DOWNLOAD_SPEED): vol.All(
+                            vol.Coerce(float), vol.Range(min=1)
+                        ),
+                        vol.Required(CONF_PAID_UPLOAD_SPEED): vol.All(
+                            vol.Coerce(float), vol.Range(min=1)
+                        ),
+                    }
+                ),
+            )
 
         return self.async_create_entry(title=DEFAULT_NAME, data=user_input)
 

--- a/homeassistant/components/speedtestdotnet/const.py
+++ b/homeassistant/components/speedtestdotnet/const.py
@@ -7,6 +7,9 @@ DOMAIN: Final = "speedtestdotnet"
 
 CONF_SERVER_NAME: Final = "server_name"
 CONF_SERVER_ID: Final = "server_id"
+CONF_PAID_DOWNLOAD_SPEED: Final = "paid_download_speed"
+CONF_PAID_UPLOAD_SPEED: Final = "paid_upload_speed"
+
 
 ATTR_BYTES_RECEIVED: Final = "bytes_received"
 ATTR_BYTES_SENT: Final = "bytes_sent"

--- a/homeassistant/components/speedtestdotnet/coordinator.py
+++ b/homeassistant/components/speedtestdotnet/coordinator.py
@@ -69,7 +69,39 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self.api.download()
         self.api.upload()
-        return cast(dict[str, Any], self.api.results.dict())
+        result_dict = cast(dict[str, Any], self.api.results.dict())
+        result_dict["funny_rating"] = self.generate_funny_rating(
+            round(result_dict["download"] / 10**6, 2),
+            result_dict["ping"],
+        )
+        return result_dict
+
+    def generate_funny_rating(self, download: float, ping: float) -> str:
+        """Generate a funny rating based on download speed."""
+
+        funny_rating = ""
+        if ping > 200:
+            funny_rating = "Every online shooter's worst nightmare."
+        elif download < 1:
+            funny_rating = "Literal potato speeds."
+        elif download < 10:
+            funny_rating = "Kinda trashy."
+        elif download < 50:
+            funny_rating = "Granny dial-up internet."
+        elif download < 100:
+            funny_rating = "Nothing special, really"
+        elif download < 250:
+            funny_rating = "Just above average. Bet you feel special."
+        elif download < 500:
+            funny_rating = "You're probably paying too much."
+        elif download < 750:
+            funny_rating = "Is it bring your HomeAssistant to work day?"
+        elif download <= 1000:
+            funny_rating = "Dude. Stop."
+        elif download > 1000:
+            funny_rating = "Absolutely God-tier."
+
+        return funny_rating
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update Speedtest data."""

--- a/homeassistant/components/speedtestdotnet/coordinator.py
+++ b/homeassistant/components/speedtestdotnet/coordinator.py
@@ -71,14 +71,13 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.api.upload()
         result_dict = cast(dict[str, Any], self.api.results.dict())
         result_dict["funny_rating"] = self.generate_funny_rating(
-            round(result_dict["download"] / 10**6, 2),
-            result_dict["ping"],
+            float(round(result_dict["download"] / 10**6, 2)),
+            float(result_dict["ping"]),
         )
         return result_dict
 
     def generate_funny_rating(self, download: float, ping: float) -> str:
         """Generate a funny rating based on download speed."""
-
         funny_rating = ""
         if ping > 200:
             funny_rating = "Every online shooter's worst nightmare."

--- a/homeassistant/components/speedtestdotnet/coordinator.py
+++ b/homeassistant/components/speedtestdotnet/coordinator.py
@@ -123,7 +123,9 @@ class SpeedTestDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             paid_download = self.config_entry.data.get(CONF_PAID_DOWNLOAD_SPEED)
             paid_upload = self.config_entry.data.get(CONF_PAID_UPLOAD_SPEED)
             notif = SpeedtestdotnetNotifications()
-            notif.create(self.hass, int(str(paid_download)), int(str(paid_upload)))
+            notif.create(
+                self.hass, int(float(str(paid_download))), int(float(str(paid_upload)))
+            )
             await notif.update(self.hass)
         except (AttributeError, KeyError, ValueError):
             pass

--- a/homeassistant/components/speedtestdotnet/manifest.json
+++ b/homeassistant/components/speedtestdotnet/manifest.json
@@ -3,6 +3,7 @@
   "name": "Speedtest.net",
   "codeowners": ["@rohankapoorcom", "@engrbm87"],
   "config_flow": true,
+  "dependencies": ["recorder"],
   "documentation": "https://www.home-assistant.io/integrations/speedtestdotnet",
   "iot_class": "cloud_polling",
   "requirements": ["speedtest-cli==2.1.3"]

--- a/homeassistant/components/speedtestdotnet/manifest.json
+++ b/homeassistant/components/speedtestdotnet/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "speedtestdotnet",
   "name": "Speedtest.net",
+  "after_dependencies": ["recorder"],
   "codeowners": ["@rohankapoorcom", "@engrbm87"],
   "config_flow": true,
-  "dependencies": ["recorder"],
   "documentation": "https://www.home-assistant.io/integrations/speedtestdotnet",
   "iot_class": "cloud_polling",
   "requirements": ["speedtest-cli==2.1.3"]

--- a/homeassistant/components/speedtestdotnet/notifications.py
+++ b/homeassistant/components/speedtestdotnet/notifications.py
@@ -6,11 +6,7 @@ from homeassistant.components import persistent_notification
 from homeassistant.components.recorder import history
 from homeassistant.core import HomeAssistant
 
-# from homeassistant.helpers import event
 
-
-# await SpeedtestdotnetNotifications.create(hass, 100, 100)
-# from notifications import SpeedtestdotnetNotifications
 class SpeedtestdotnetNotifications:
     """Class updating average sensor states."""
 
@@ -41,6 +37,9 @@ class SpeedtestdotnetNotifications:
         },
     ]
 
+    def __init__(self) -> None:
+        """Initialise the SpeedtestdotnetNotifications class."""
+
     @classmethod
     async def create(
         cls,
@@ -53,7 +52,6 @@ class SpeedtestdotnetNotifications:
         self.hass = hass
         self.sensors[0]["max_value"] = paid_download
         self.sensors[2]["max_value"] = paid_upload
-        await self.update()
 
     def average(self, data: list) -> dict:
         """Calculate averges of each sensor's data.
@@ -94,7 +92,7 @@ class SpeedtestdotnetNotifications:
         result = {}
 
         for sensor in self.sensors:
-            current_data = data[sensor["id"]]
+            current_data = data[sensor["name"]]
             # Check if the sensor data is within the acceptable threshold.
             if self.compare(current_data["value"], sensor):
                 result[sensor["name"]] = True
@@ -133,7 +131,7 @@ class SpeedtestdotnetNotifications:
                 sensor["id"],
                 True,
             )
-            averages[sensor["id"]] = self.average(response[str(sensor["id"])])
+            averages[sensor["name"]] = self.average(response[str(sensor["id"])])
 
         # Validate average values
         result = self.validate(averages)

--- a/homeassistant/components/speedtestdotnet/notifications.py
+++ b/homeassistant/components/speedtestdotnet/notifications.py
@@ -1,0 +1,149 @@
+""""Support for calculating average sensor states and sending notifications."""
+import datetime as dt
+from datetime import timedelta
+
+from homeassistant.components import persistent_notification
+from homeassistant.components.recorder import history
+from homeassistant.core import HomeAssistant
+
+# from homeassistant.helpers import event
+
+
+# await SpeedtestdotnetNotifications.create(hass, 100, 100)
+# from notifications import SpeedtestdotnetNotifications
+class SpeedtestdotnetNotifications:
+    """Class updating average sensor states."""
+
+    hass: HomeAssistant
+    # Information and threshold functions for each sensor
+    sensors = [
+        {
+            "name": "download",
+            "id": "sensor.speedtest_download",
+            "function": lambda a: a,
+            "threshold": 0.9,
+            "less_than": False,
+        },
+        {
+            "name": "ping",
+            "id": "sensor.speedtest_ping",
+            "function": lambda a: a,
+            "threshold": 1.0,
+            "max_value": 50,
+            "less_than": True,
+        },
+        {
+            "name": "upload",
+            "id": "sensor.speedtest_upload",
+            "function": lambda a: a,
+            "threshold": 0.8,
+            "less_than": False,
+        },
+    ]
+
+    @classmethod
+    async def create(
+        cls,
+        hass: HomeAssistant,
+        paid_download: int,
+        paid_upload: int,
+    ) -> None:
+        """Initialise the SpeedtestdotnetNotifications class."""
+        self = cls()
+        self.hass = hass
+        self.sensors[0]["max_value"] = paid_download
+        self.sensors[2]["max_value"] = paid_upload
+        await self.update()
+
+    def average(self, data: list) -> dict:
+        """Calculate averges of each sensor's data.
+
+        Returns a dictionary with the sum, count, and average (value) of each sensor.
+        """
+        # Setup dictionary to store average results of each sensor
+        result = {"sum": 0.0, "count": 0, "value": 0.0}
+
+        # Count the sum of all states
+        for item in data:
+            try:
+                result["sum"] += float(item.state)
+                result["count"] += 1
+            except ValueError:
+                pass
+
+        # Calculate the average value (state)
+        if result["count"] > 0:
+            result["value"] = result["sum"] / result["count"]
+
+        return result
+
+    def compare(self, value: int, sensor_data: dict) -> bool:
+        """Compare average value with threshold."""
+        if not sensor_data["less_than"]:
+            return value > int(sensor_data["max_value"]) * float(
+                sensor_data["threshold"]
+            )
+
+        return value < int(sensor_data["max_value"]) * float(sensor_data["threshold"])
+
+    def validate(self, data: dict) -> dict:
+        """Validate sensor data to see if the minimum thresholds are met.
+
+        Returns a dictionary with the result of each sensor.
+        """
+        result = {}
+
+        for sensor in self.sensors:
+            current_data = data[sensor["id"]]
+            # Check if the sensor data is within the acceptable threshold.
+            if self.compare(current_data["value"], sensor):
+                result[sensor["name"]] = True
+            else:
+                result[sensor["name"]] = False
+
+        return result
+
+    def state_change(self, hass: HomeAssistant) -> None:
+        """Track when sensor states have changed to initiate a new evaluation.
+
+        TODO: Possible changes:
+        1. update function is called from sensor.py
+        2. Updates are run on a 24 hr interval instead.
+        """
+        # event.async_track_time_change(hass, self.update(), 14, 27, None)
+
+    def send_notification(self, title: str, message: str) -> None:
+        """Send a notification using the REST API to the home assistant UI."""
+        persistent_notification.create(self.hass, message=message, title=title)
+
+    async def update(self) -> bool:
+        """Update and validate sensor averages."""
+        # Get sensor data from the past month
+        thirty_days_ago = dt.datetime.now(dt.UTC) - timedelta(days=30)
+        result = {}
+        averages = {}
+
+        # Get average values from each sensor
+        for sensor in self.sensors:
+            response = await self.hass.async_add_executor_job(
+                history.state_changes_during_period,
+                self.hass,
+                thirty_days_ago,
+                None,
+                sensor["id"],
+                True,
+            )
+            averages[sensor["id"]] = self.average(response[str(sensor["id"])])
+
+        # Validate average values
+        result = self.validate(averages)
+
+        # Check if any sensor failed to meet the requirement and send a notification to the user.
+        failed_sensors = [x for x in self.sensors if result[x["name"]] is False]
+        if len(failed_sensors) > 0:
+            failed_sensors_str = ", ".join([str(x["name"]) for x in failed_sensors])
+            title = "Internet speed is slower than expected."
+            message = f"Speedtest.net has detected that the internet speed does not meet the minimum acceptable requirement this month. Affected sensor(s) is/are {failed_sensors_str}.\n\nPlease find more information about how to improve connection speeds on our knowledgebase (https://www.speedtest.net/about/knowledge). \n\nIf you get this notification often, try changing the minimum threshold values in the integration settings."
+            self.send_notification(title, message)
+
+        return True

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, cast
 
+from notifications import SpeedtestdotnetNotifications
+
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
@@ -75,6 +77,7 @@ async def async_setup_entry(
         SpeedtestSensor(speedtest_coordinator, description)
         for description in SENSOR_TYPES
     )
+    await SpeedtestdotnetNotifications.create(hass, 100, 100)
 
 
 # pylint: disable-next=hass-invalid-inheritance # needs fixing

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -64,6 +64,11 @@ SENSOR_TYPES: tuple[SpeedtestSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATA_RATE,
         value=lambda value: round(value / 10**6, 2),
     ),
+    SpeedtestSensorEntityDescription(
+        key="funny_rating",
+        translation_key="funny_rating",
+        value=lambda value: value,
+    ),
 )
 
 

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfDataRate, UnitOfTime
+from homeassistant.const import PERCENTAGE, UnitOfDataRate, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -63,6 +63,18 @@ SENSOR_TYPES: tuple[SpeedtestSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.DATA_RATE,
         value=lambda value: round(value / 10**6, 2),
+    ),
+    SpeedtestSensorEntityDescription(
+        key="download_percentage",
+        translation_key="download_percentage",
+        native_unit_of_measurement=PERCENTAGE,
+        value=lambda value: value if value is not None else None,
+    ),
+    SpeedtestSensorEntityDescription(
+        key="upload_percentage",
+        translation_key="upload_percentage",
+        native_unit_of_measurement=PERCENTAGE,
+        value=lambda value: value if value is not None else None,
     ),
 )
 

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -5,8 +5,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, cast
 
-from notifications import SpeedtestdotnetNotifications
-
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
@@ -33,6 +31,7 @@ from .const import (
     ICON,
 )
 from .coordinator import SpeedTestDataCoordinator
+from .notifications import SpeedtestdotnetNotifications
 
 
 @dataclass

--- a/homeassistant/components/speedtestdotnet/sensor.py
+++ b/homeassistant/components/speedtestdotnet/sensor.py
@@ -31,7 +31,6 @@ from .const import (
     ICON,
 )
 from .coordinator import SpeedTestDataCoordinator
-from .notifications import SpeedtestdotnetNotifications
 
 
 @dataclass
@@ -47,7 +46,6 @@ SENSOR_TYPES: tuple[SpeedtestSensorEntityDescription, ...] = (
         translation_key="ping",
         native_unit_of_measurement=UnitOfTime.MILLISECONDS,
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.DURATION,
     ),
     SpeedtestSensorEntityDescription(
         key="download",
@@ -96,7 +94,6 @@ async def async_setup_entry(
         SpeedtestSensor(speedtest_coordinator, description)
         for description in SENSOR_TYPES
     )
-    await SpeedtestdotnetNotifications.create(hass, 100, 100)
 
 
 class SpeedtestSensor(CoordinatorEntity[SpeedTestDataCoordinator], SensorEntity):

--- a/homeassistant/components/speedtestdotnet/strings.json
+++ b/homeassistant/components/speedtestdotnet/strings.json
@@ -28,6 +28,9 @@
       },
       "upload": {
         "name": "Upload"
+      },
+      "funny_rating": {
+        "name": "Funny rating"
       }
     }
   }

--- a/homeassistant/components/speedtestdotnet/strings.json
+++ b/homeassistant/components/speedtestdotnet/strings.json
@@ -28,6 +28,12 @@
       },
       "upload": {
         "name": "Upload"
+      },
+      "download_percentage": {
+        "name": "Download percentage"
+      },
+      "upload_percentage": {
+        "name": "Upload percentage"
       }
     }
   }

--- a/tests/components/speedtestdotnet/__init__.py
+++ b/tests/components/speedtestdotnet/__init__.py
@@ -35,6 +35,7 @@ MOCK_RESULTS = {
     "download": 1024000,
     "upload": 1024000,
     "ping": 18.465,
+    "funny_rating": "Kinda trashy.",
     "server": {
         "url": "http://test_server:8080/speedtest/upload.php",
         "lat": "00.0000",
@@ -52,4 +53,9 @@ MOCK_RESULTS = {
     "share": None,
 }
 
-MOCK_STATES = {"ping": "18", "download": "1.02", "upload": "1.02"}
+MOCK_STATES = {
+    "ping": "18",
+    "download": "1.02",
+    "upload": "1.02",
+    "funny_rating": "Kinda trashy.",
+}

--- a/tests/components/speedtestdotnet/test_config_flow.py
+++ b/tests/components/speedtestdotnet/test_config_flow.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock
 from homeassistant import config_entries
 from homeassistant.components import speedtestdotnet
 from homeassistant.components.speedtestdotnet.const import (
+    CONF_PAID_DOWNLOAD_SPEED,
+    CONF_PAID_UPLOAD_SPEED,
     CONF_SERVER_ID,
     CONF_SERVER_NAME,
     DOMAIN,
@@ -22,8 +24,10 @@ async def test_flow_works(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
+    user_input = {CONF_PAID_DOWNLOAD_SPEED: 50.0, CONF_PAID_UPLOAD_SPEED: 30.0}
+
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
+        result["flow_id"], user_input=user_input
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
 
@@ -87,3 +91,35 @@ async def test_integration_already_configured(hass: HomeAssistant) -> None:
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+
+
+async def test_valid_paid_speed_input(hass: HomeAssistant) -> None:
+    """Test valid paid download and upload speed input."""
+    result = await hass.config_entries.flow.async_init(
+        speedtestdotnet.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    user_input = {CONF_PAID_DOWNLOAD_SPEED: 50.0, CONF_PAID_UPLOAD_SPEED: 30.0}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=user_input
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_default_paid_speed_input(hass: HomeAssistant) -> None:
+    """Test default paid download and upload speed input."""
+    result = await hass.config_entries.flow.async_init(
+        speedtestdotnet.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    user_input = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=user_input
+    )
+    assert result["type"] == FlowResultType.FORM

--- a/tests/components/speedtestdotnet/test_coordinator.py
+++ b/tests/components/speedtestdotnet/test_coordinator.py
@@ -1,6 +1,8 @@
 """Tests for SpeedTest coordinator."""
 from unittest.mock import Mock
+
 import pytest
+
 from homeassistant.components.speedtestdotnet import SpeedTestDataCoordinator
 from homeassistant.core import HomeAssistant
 
@@ -35,6 +37,7 @@ async def test_calc_upload_percentage() -> None:
         actual_download_speed, paid_download_speed
     )
     assert result == expected_percentage
+
 
 @pytest.mark.parametrize(
     ("download", "ping", "expected_result"),

--- a/tests/components/speedtestdotnet/test_coordinator.py
+++ b/tests/components/speedtestdotnet/test_coordinator.py
@@ -1,0 +1,24 @@
+"""Tests for SpeedTest coordinator."""
+
+import pytest
+
+from homeassistant.components.speedtestdotnet import SpeedTestDataCoordinator
+
+
+@pytest.mark.parametrize(
+    ("download", "ping", "expected_result"),
+    [
+        (0.5, 10, "Literal potato speeds."),
+        (5, 10, "Kinda trashy."),
+        (25, 10, "Granny dial-up internet."),
+        (75, 10, "Nothing special, really"),
+        (150, 10, "Just above average. Bet you feel special."),
+        (100, 250, "Every online shooter's worst nightmare."),
+    ],
+)
+def test_generate_funny_rating(download, ping, expected_result) -> None:
+    """Test the generate_funny_rating function."""
+    assert (
+        SpeedTestDataCoordinator.generate_funny_rating(None, download, ping)
+        == expected_result
+    )

--- a/tests/components/speedtestdotnet/test_coordinator.py
+++ b/tests/components/speedtestdotnet/test_coordinator.py
@@ -1,0 +1,39 @@
+"""Tests for SpeedTest coordinator."""
+from unittest.mock import Mock
+
+from homeassistant.components.speedtestdotnet.coordinator import (
+    SpeedTestDataCoordinator,
+)
+from homeassistant.core import HomeAssistant
+
+
+async def test_calc_download_percentage() -> None:
+    """Test the calculation of the upload percentage function."""
+    hass = Mock(spec=HomeAssistant)
+    coordinator = SpeedTestDataCoordinator(hass, None, None)
+
+    paid_download_speed = 50.0
+    actual_download_speed = 40.0
+
+    expected_percentage = (actual_download_speed / paid_download_speed) * 100
+
+    result = coordinator.calc_download_percentage_test(
+        actual_download_speed, paid_download_speed
+    )
+    assert result == expected_percentage
+
+
+async def test_calc_upload_percentage() -> None:
+    """Test the calculation of the upload percentage function."""
+    hass = Mock(spec=HomeAssistant)
+    coordinator = SpeedTestDataCoordinator(hass, None, None)
+
+    paid_download_speed = 50.0
+    actual_download_speed = 40.0
+
+    expected_percentage = (actual_download_speed / paid_download_speed) * 100
+
+    result = coordinator.calc_upload_percentage_test(
+        actual_download_speed, paid_download_speed
+    )
+    assert result == expected_percentage

--- a/tests/components/speedtestdotnet/test_notifications.py
+++ b/tests/components/speedtestdotnet/test_notifications.py
@@ -1,22 +1,77 @@
 """Tests for SpeedTest notification."""
+from homeassistant.components.speedtestdotnet.notifications import (
+    SpeedtestdotnetNotifications,
+)
+from homeassistant.core import HomeAssistant
 
 MAX_STATES = {"download": 100, "upload": 100}
+sensor_names = ["download", "ping", "upload"]
+
+
+class MockNotificationsState:
+    """Mock class for state attribute."""
+
+    def __init__(self, state: str) -> None:
+        """Initialise class."""
+        self.state = state
+
 
 MOCK_STATES = [
-    {"ping": 18, "download": 45.68, "upload": 83.79},
-    {"ping": 18, "download": 98.43, "upload": 76.16},
-    {"ping": 53, "download": 98.43, "upload": 83.79},
-    {"ping": 53, "download": 45.68, "upload": 83.79},
-    {"ping": 18, "download": 45.68, "upload": 76.16},
-    {"ping": 53, "download": 98.43, "upload": 76.16},
+    {
+        "download": [
+            MockNotificationsState("45"),  # 50
+            MockNotificationsState("55"),
+        ],
+        "ping": [
+            MockNotificationsState("55"),  # 60
+            MockNotificationsState("65"),
+        ],
+        "upload": [
+            MockNotificationsState("70.0"),  # 65
+            MockNotificationsState("60.0"),
+        ],
+    },
+    {
+        "download": [
+            MockNotificationsState("98.56"),  # 99.28
+            MockNotificationsState("100.00"),
+        ],
+        "ping": [
+            MockNotificationsState("20"),
+            MockNotificationsState("14"),
+        ],
+        "upload": [
+            MockNotificationsState("90.0"),  # 85
+            MockNotificationsState("80.0"),
+        ],
+    },
+]
+
+MOCK_AVG_RESULTS = [
+    {"download": {"value": 50.0}, "ping": {"value": 60.0}, "upload": {"value": 65.0}},
+    {"download": {"value": 99.28}, "ping": {"value": 17.0}, "upload": {"value": 85.0}},
+]
+
+MOCK_VALIDATE_RESULTS = [
+    {"download": False, "ping": False, "upload": False},
+    {"download": True, "ping": True, "upload": True},
 ]
 
 
-async def test_history_average() -> None:
+async def test_history_average(hass: HomeAssistant) -> None:
     """Test averaging history states."""
-    return
+    notif = SpeedtestdotnetNotifications()
+    await notif.create(hass, 100, 100)
+    for i, val in enumerate(MOCK_STATES):
+        for sensor_name in sensor_names:
+            result = notif.average(val[sensor_name])
+            assert result["value"] == MOCK_AVG_RESULTS[i][sensor_name]["value"]
 
 
-async def test_validate() -> None:
+async def test_validate(hass: HomeAssistant) -> None:
     """Test validating averages."""
-    return
+    notif = SpeedtestdotnetNotifications()
+    await notif.create(hass, 100, 100)
+    for i, val in enumerate(MOCK_AVG_RESULTS):
+        result = notif.validate(val)
+        assert result == MOCK_VALIDATE_RESULTS[i]

--- a/tests/components/speedtestdotnet/test_notifications.py
+++ b/tests/components/speedtestdotnet/test_notifications.py
@@ -1,0 +1,22 @@
+"""Tests for SpeedTest notification."""
+
+MAX_STATES = {"download": 100, "upload": 100}
+
+MOCK_STATES = [
+    {"ping": 18, "download": 45.68, "upload": 83.79},
+    {"ping": 18, "download": 98.43, "upload": 76.16},
+    {"ping": 53, "download": 98.43, "upload": 83.79},
+    {"ping": 53, "download": 45.68, "upload": 83.79},
+    {"ping": 18, "download": 45.68, "upload": 76.16},
+    {"ping": 53, "download": 98.43, "upload": 76.16},
+]
+
+
+async def test_history_average() -> None:
+    """Test averaging history states."""
+    return
+
+
+async def test_validate() -> None:
+    """Test validating averages."""
+    return

--- a/tests/components/speedtestdotnet/test_notifications.py
+++ b/tests/components/speedtestdotnet/test_notifications.py
@@ -127,15 +127,3 @@ async def test_update(
     await notif.create(hass, MAX_STATES["upload"], MAX_STATES["upload"])
 
     assert await notif.update() is True
-    # assert await notif.update() == MOCK_STATES[0]["download"]
-
-    # real.update = MagicMock(name="update")
-    # real.update(None)
-    # real.update.return_value = "Test"
-    # result = real.update.assert_called()
-
-    # MagicMock.attach_mock()
-    # MagicMock._mock_add_spec()
-    # MagicMock.configure_mock(real.update, {'notif.update.return_value': 50} )
-    # MagicMock.reset_mock()
-    # assert result == None

--- a/tests/components/speedtestdotnet/test_notifications.py
+++ b/tests/components/speedtestdotnet/test_notifications.py
@@ -1,10 +1,10 @@
 """Tests for SpeedTest notification."""
-from homeassistant.components.speedtestdotnet.notifications import (
-    SpeedtestdotnetNotifications,
-)
+from unittest.mock import patch
+
+from homeassistant.components.speedtestdotnet import notifications as n
 from homeassistant.core import HomeAssistant
 
-MAX_STATES = {"download": 100, "upload": 100}
+MAX_STATES = {"download": 100, "ping": 50, "upload": 100}
 sensor_names = ["download", "ping", "upload"]
 
 
@@ -45,23 +45,51 @@ MOCK_STATES = [
             MockNotificationsState("80.0"),
         ],
     },
+    {
+        "download": [MockNotificationsState("98,56")],
+        "ping": [MockNotificationsState("2-0")],
+        "upload": [MockNotificationsState("90Ä0")],
+    },
 ]
 
 MOCK_AVG_RESULTS = [
-    {"download": {"value": 50.0}, "ping": {"value": 60.0}, "upload": {"value": 65.0}},
-    {"download": {"value": 99.28}, "ping": {"value": 17.0}, "upload": {"value": 85.0}},
+    {
+        "download": {"value": 50.0, "count": 2},
+        "ping": {"value": 60.0, "count": 2},
+        "upload": {"value": 65.0, "count": 2},
+    },
+    {
+        "download": {"value": 99.28, "count": 2},
+        "ping": {"value": 17.0, "count": 2},
+        "upload": {"value": 85.0, "count": 2},
+    },
+    {
+        "download": {"value": 0.0, "count": 0},
+        "ping": {"value": 0.0, "count": 0},
+        "upload": {"value": 0.0, "count": 0},
+    },
 ]
 
 MOCK_VALIDATE_RESULTS = [
     {"download": False, "ping": False, "upload": False},
     {"download": True, "ping": True, "upload": True},
+    {"download": False, "ping": False, "upload": False},
 ]
+
+MOCK_COMPARE = [
+    {"value": 80, "threshold": 0.9, "less_than": False, "max_value": 100},
+    {"value": 95, "threshold": 0.9, "less_than": False, "max_value": 100},
+    {"value": 80, "threshold": 1.0, "less_than": True, "max_value": 50},
+    {"value": 30, "threshold": 1.0, "less_than": True, "max_value": 50},
+]
+
+MOCK_COMPARE_RESULTS = [False, True, False, True]
 
 
 async def test_history_average(hass: HomeAssistant) -> None:
     """Test averaging history states."""
-    notif = SpeedtestdotnetNotifications()
-    await notif.create(hass, 100, 100)
+    notif = n.SpeedtestdotnetNotifications()
+    await notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
     for i, val in enumerate(MOCK_STATES):
         for sensor_name in sensor_names:
             result = notif.average(val[sensor_name])
@@ -70,8 +98,44 @@ async def test_history_average(hass: HomeAssistant) -> None:
 
 async def test_validate(hass: HomeAssistant) -> None:
     """Test validating averages."""
-    notif = SpeedtestdotnetNotifications()
-    await notif.create(hass, 100, 100)
+    notif = n.SpeedtestdotnetNotifications()
+    await notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
     for i, val in enumerate(MOCK_AVG_RESULTS):
         result = notif.validate(val)
         assert result == MOCK_VALIDATE_RESULTS[i]
+
+
+async def test_compare(hass: HomeAssistant) -> None:
+    """Test the compare function for state thresholds."""
+    notif = n.SpeedtestdotnetNotifications()
+    await notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
+
+    for i, val in enumerate(MOCK_COMPARE):
+        result = notif.compare(val["value"], val)
+        assert result == MOCK_COMPARE_RESULTS[i]
+
+
+@patch.object(n.SpeedtestdotnetNotifications, "get_sensor_history")
+@patch.object(n.SpeedtestdotnetNotifications, "send_notification")
+async def test_update(
+    mock_history, mock_send_notification, hass: HomeAssistant
+) -> None:
+    """Test the update method."""
+    mock_history.get_sensor_history.side_effect = MOCK_STATES
+    mock_history.mock_send_notification.return_value = None
+    notif = n.SpeedtestdotnetNotifications()
+    await notif.create(hass, MAX_STATES["upload"], MAX_STATES["upload"])
+
+    assert await notif.update() is True
+    # assert await notif.update() == MOCK_STATES[0]["download"]
+
+    # real.update = MagicMock(name="update")
+    # real.update(None)
+    # real.update.return_value = "Test"
+    # result = real.update.assert_called()
+
+    # MagicMock.attach_mock()
+    # MagicMock._mock_add_spec()
+    # MagicMock.configure_mock(real.update, {'notif.update.return_value': 50} )
+    # MagicMock.reset_mock()
+    # assert result == None

--- a/tests/components/speedtestdotnet/test_notifications.py
+++ b/tests/components/speedtestdotnet/test_notifications.py
@@ -89,7 +89,7 @@ MOCK_COMPARE_RESULTS = [False, True, False, True]
 async def test_history_average(hass: HomeAssistant) -> None:
     """Test averaging history states."""
     notif = n.SpeedtestdotnetNotifications()
-    await notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
+    notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
     for i, val in enumerate(MOCK_STATES):
         for sensor_name in sensor_names:
             result = notif.average(val[sensor_name])
@@ -99,7 +99,7 @@ async def test_history_average(hass: HomeAssistant) -> None:
 async def test_validate(hass: HomeAssistant) -> None:
     """Test validating averages."""
     notif = n.SpeedtestdotnetNotifications()
-    await notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
+    notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
     for i, val in enumerate(MOCK_AVG_RESULTS):
         result = notif.validate(val)
         assert result == MOCK_VALIDATE_RESULTS[i]
@@ -108,7 +108,7 @@ async def test_validate(hass: HomeAssistant) -> None:
 async def test_compare(hass: HomeAssistant) -> None:
     """Test the compare function for state thresholds."""
     notif = n.SpeedtestdotnetNotifications()
-    await notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
+    notif.create(hass, MAX_STATES["download"], MAX_STATES["upload"])
 
     for i, val in enumerate(MOCK_COMPARE):
         result = notif.compare(val["value"], val)
@@ -124,6 +124,6 @@ async def test_update(
     mock_history.get_sensor_history.side_effect = MOCK_STATES
     mock_history.mock_send_notification.return_value = None
     notif = n.SpeedtestdotnetNotifications()
-    await notif.create(hass, MAX_STATES["upload"], MAX_STATES["upload"])
+    notif.create(hass, MAX_STATES["upload"], MAX_STATES["upload"])
 
-    assert await notif.update() is True
+    assert await notif.update(hass) is True

--- a/tests/components/speedtestdotnet/test_sensor.py
+++ b/tests/components/speedtestdotnet/test_sensor.py
@@ -23,7 +23,7 @@ async def test_speedtestdotnet_sensors(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 5
 
     sensor = hass.states.get("sensor.speedtest_ping")
     assert sensor

--- a/tests/components/speedtestdotnet/test_sensor.py
+++ b/tests/components/speedtestdotnet/test_sensor.py
@@ -23,7 +23,7 @@ async def test_speedtestdotnet_sensors(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
 
     sensor = hass.states.get("sensor.speedtest_ping")
     assert sensor
@@ -36,3 +36,7 @@ async def test_speedtestdotnet_sensors(
     sensor = hass.states.get("sensor.speedtest_ping")
     assert sensor
     assert sensor.state == MOCK_STATES["ping"]
+
+    sensor = hass.states.get("sensor.speedtest_funny_rating")
+    assert sensor
+    assert sensor.state == MOCK_STATES["funny_rating"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updated the speedtest integration to include a funny rating as well as a percentage rating of the internet speed a user is paying for. Any major slowdowns will result in a notification being send to the web interface. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

Speedtestdotnet is an integration which uses speedtest servers to measure the users upload and download speeds as well as ping. By default this is run every hour. The server to be tested against is autodetected but can be manually selected if desired.

We have updated the speedtest integration to include a funny rating as well as a percentage rating of the internet speed a user is paying for. Any major slowdowns will result in a notification being send to the web interface.  

