### PR TITLE
changes in openmeteo

### DIFF
--- a/tests/components/open_meteo/test_weather.py
+++ b/tests/components/open_meteo/test_weather.py
@@ -1,0 +1,72 @@
+from homeassistant.components.weather import WeatherEntity
+from homeassistant.const import (
+    TEMP_CELSIUS,
+    SPEED_KILOMETERS_PER_HOUR,
+    LENGTH_MILLIMETERS,
+)
+from homeassistant.util import dt as dt_util
+from open_meteo import Forecast as OpenMeteoForecast
+from unittest.mock import Mock
+
+# Import DOMAIN from your component's const.py file
+from homeassistant.components.open_meteo.const import DOMAIN
+from homeassistant.components.open_meteo.weather import OpenMeteoWeatherEntity
+
+
+async def test_open_meteo_entity_properties():
+    """Test the OpenMeteo weather entity properties."""
+    entry = Mock()
+    coordinator = Mock()
+    coordinator.data = OpenMeteoForecast()
+    coordinator.data.current_weather = Mock()
+    coordinator.data.current_weather.weather_code = "clear-night"
+    coordinator.data.current_weather.temperature = 20.5
+    coordinator.data.current_weather.wind_speed = 5.0
+    coordinator.data.current_weather.wind_direction = 180
+
+    entity = OpenMeteoWeatherEntity(entry=entry, coordinator=coordinator)
+
+    assert entity.name is None
+    assert entity.unique_id == entry.entry_id
+    assert entity.device_info.manufacturer == "Open-Meteo"
+    assert entity.device_info.name == entry.title
+    assert entity.device_info.identifiers == {(DOMAIN, entry.entry_id)}
+
+    assert entity.condition == "clear-night"
+    assert entity.native_temperature == 20.5
+    assert entity.native_temperature_unit == TEMP_CELSIUS
+    assert entity.native_wind_speed == 5.0
+    assert entity.native_wind_speed_unit == SPEED_KILOMETERS_PER_HOUR
+    assert entity.wind_bearing == 180
+
+
+async def test_open_meteo_entity_forecast():
+    """Test the OpenMeteo weather entity forecast."""
+    entry = Mock()
+    coordinator = Mock()
+    coordinator.data = OpenMeteoForecast()
+    coordinator.data.daily = Mock()
+    coordinator.data.daily.time = [dt_util.now(), dt_util.now()]
+    coordinator.data.daily.weathercode = ["clear-day", "partly-cloudy-day"]
+    coordinator.data.daily.precipitation_sum = [0.0, 2.5]
+    coordinator.data.daily.temperature_2m_max = [25.0, 20.0]
+    coordinator.data.daily.temperature_2m_min = [15.0, 10.0]
+    coordinator.data.daily.wind_direction_10m_dominant = [180, 270]
+    coordinator.data.daily.wind_speed_10m_max = [10.0, 15.0]
+
+    entity = OpenMeteoWeatherEntity(entry=entry, coordinator=coordinator)
+    forecasts = entity.forecast
+
+    assert len(forecasts) == 2
+
+    forecast_today = forecasts[0]
+    assert forecast_today.datetime is not None
+    assert forecast_today.condition == "clear-day"
+    assert forecast_today.native_precipitation == 0.0
+    assert forecast_today.native_precipitation_unit == LENGTH_MILLIMETERS
+    assert forecast_today.native_temperature == 25.0
+    assert forecast_today.native_temperature_unit == TEMP_CELSIUS
+    assert forecast_today.native_templow == 15.0
+    assert forecast_today.wind_bearing == 180
+    assert forecast_today.native_wind_speed == 10.0
+    assert forecast_today.native_wind_speed_unit == SPEED_KILOMETERS_PER_HOUR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

Description:

Feature wind bearing-In the initial configuration of our Home Assistant dashboard, the wind bearing parameter was conspicuously absent. This posed a limitation, as users could not readily view the direction from which the wind was originating. Recognizing the importance of this metric — especially for those who rely on precise meteorological data for daily activities — we took the initiative to enhance the dashboard. As depicted in the subsequent figure, we successfully integrated the wind bearing attribute. This augmentation not only provides a more comprehensive view of the weather conditions but also elevates the user experience, offering a seamless interface where one can access all pertinent weather details at a glance.
 
Feature email-We have recently rolled out a pivotal enhancement to our EMAIL_AUTOMATION feature, geared towards keeping users informed and prepared for their day. With this latest addition, users are automatically sent an email every day precisely at 8 am, providing insights into the day's temperature. This temperature data is meticulously sourced from the reliable Open-Meteo integration, which also offers a plethora of other meteorological attributes such as wind bearing, wind speed, and so on.

However, our primary focus for this feature was the temperature. Given the paramount importance of temperature information - especially in regions with severe cold - we deemed it essential for users to have this detail at their fingertips as they start their day. It assists in making informed decisions about attire, travel, and other daily activities.

The ensuing figure vividly demonstrates our email notification system in action, showcasing how users are presented with the day's temperature. With this initiative, we aim to offer users a more proactive and informed start to their day, ensuring they are well-equipped with the crucial weather details they need.

Feature wind chill-We have added the windchill capability to our Open-Meteo integration, which is a huge improvement. This advancement was made possible by using existing temperature and windspeed properties and calculating windchill using a well-established method. The windchill number obtained is then deducted from the original temperature data.

The value of including windchill in weather data cannot be emphasized. Windchill gives critical information on how people experience weather conditions. It considers the combined effects of temperature and wind to provide a more realistic picture of subjective coldness. This knowledge is especially useful for outdoor activities because it allows people to make informed decisions about how to dress appropriately, reduce the risk of cold-related health conditions, and ensure their safety.In essence, the addition of the windchill capability improves the usefulness and dependability of our Open-Meteo integration, allowing users to make more educated weather-related decisions.
